### PR TITLE
Refactor sample selection for track/sequencer

### DIFF
--- a/src/components/sequencer/sequencer-dialog.tsx
+++ b/src/components/sequencer/sequencer-dialog.tsx
@@ -2,14 +2,13 @@ import { Sequencer } from "components/sequencer/sequencer";
 import { Dialog } from "evergreen-ui";
 import { useTrackAtom } from "utils/hooks/use-track-atom";
 import { List } from "immutable";
-import { SelectMenuItem } from "components/select-menu";
 import { FileRecord } from "models/file-record";
 import { useState } from "react";
 
 interface SequencerDialogProps {
+    files: Array<FileRecord>;
     onChange: (value: List<List<FileRecord>>) => void;
     onClose: () => void;
-    sampleOptions: Array<SelectMenuItem<FileRecord>>;
     trackId: string;
     value: List<List<FileRecord>>;
 }
@@ -17,13 +16,7 @@ interface SequencerDialogProps {
 const SequencerDialog: React.FC<SequencerDialogProps> = (
     props: SequencerDialogProps
 ) => {
-    const {
-        onChange,
-        onClose,
-        sampleOptions,
-        trackId,
-        value: initialValue,
-    } = props;
+    const { onChange, onClose, files, trackId, value: initialValue } = props;
     const { name } = useTrackAtom(trackId);
     const [value, setValue] = useState<List<List<FileRecord>>>(initialValue);
 
@@ -43,8 +36,8 @@ const SequencerDialog: React.FC<SequencerDialogProps> = (
             onConfirm={handleConfirm}
             title={`Sequencer for ${name}`}>
             <Sequencer
+                files={files}
                 onChange={handleChange}
-                options={sampleOptions}
                 trackId={trackId}
                 value={value}
             />

--- a/src/components/sequencer/sequencer.tsx
+++ b/src/components/sequencer/sequencer.tsx
@@ -1,46 +1,51 @@
 import { SequencerStep } from "components/sequencer/sequencer-step";
 import { Button, Pane } from "evergreen-ui";
 import _ from "lodash";
-import { useTrackAtom } from "utils/hooks/use-track-atom";
 import { List } from "immutable";
 import { SelectMenu, SelectMenuItem } from "components/select-menu";
 import { FileRecord } from "models/file-record";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 interface SequencerProps {
+    files: Array<FileRecord>;
     onChange: (index: number, value: List<FileRecord>) => void;
-    options: Array<SelectMenuItem<FileRecord>>;
     trackId: string;
     value: List<List<FileRecord>>;
 }
 
 const Sequencer: React.FC<SequencerProps> = (props: SequencerProps) => {
-    const { onChange, options, trackId, value } = props;
-    const [selected, setSelected] = useState<List<FileRecord>>(List());
-    useTrackAtom(trackId);
+    const { onChange, files, value } = props;
+    const [selectedFiles, setSelectedFiles] = useState<List<FileRecord>>(
+        List()
+    );
+
+    const options: Array<SelectMenuItem<FileRecord>> = useMemo(
+        () => FileRecord.toSelectMenuItems(files),
+        [files]
+    );
 
     const handleDeselect = (item: SelectMenuItem<FileRecord>) =>
-        setSelected((prev) =>
+        setSelectedFiles((prev) =>
             prev.includes(item.value)
                 ? prev.remove(prev.indexOf(item.value))
                 : prev
         );
 
     const handleSelect = (item: SelectMenuItem<FileRecord>) =>
-        setSelected((prev) =>
+        setSelectedFiles((prev) =>
             prev.includes(item.value) ? prev : prev.push(item.value)
         );
+
     return (
         <Pane>
             <SelectMenu
-                hasFilter={false}
                 isMultiSelect={true}
                 onDeselect={handleDeselect}
                 onSelect={handleSelect}
                 options={options}
-                selected={selected}
+                selected={selectedFiles}
                 title="Current Samples">
-                <Button>{selected.count()} Samples Selected</Button>
+                <Button>{selectedFiles.count()} Samples Selected</Button>
             </SelectMenu>
             <Pane
                 marginX="auto"
@@ -53,7 +58,7 @@ const Sequencer: React.FC<SequencerProps> = (props: SequencerProps) => {
                         index={index}
                         key={index}
                         onChange={onChange}
-                        selected={selected}
+                        selected={selectedFiles}
                         value={value.get(index, List())}
                     />
                 ))}

--- a/src/components/track.tsx
+++ b/src/components/track.tsx
@@ -7,25 +7,23 @@ import {
     IconButton,
     majorScale,
     minorScale,
-    MusicIcon,
     Pane,
     PropertiesIcon,
     PropertyIcon,
+    Spinner,
     Tooltip,
     VolumeOffIcon,
     VolumeUpIcon,
 } from "evergreen-ui";
 import { Track as TrackInterface } from "interfaces/track";
 import { FileRecord } from "models/file-record";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useListFiles } from "utils/hooks/domain/files/use-list-files";
 import { useBoolean } from "utils/hooks/use-boolean";
 import { useTrackAtom } from "utils/hooks/use-track-atom";
 import { List } from "immutable";
-import { SelectMenu, SelectMenuItem } from "components/select-menu";
 import { initializeList } from "utils/core-utils";
 import { Track as ReactronicaTrack, Instrument } from "reactronica";
-import { ToneAudioBuffer } from "tone";
 
 interface TrackProps extends TrackInterface {
     index: number;
@@ -34,9 +32,8 @@ interface TrackProps extends TrackInterface {
 const iconMarginRight = minorScale(2);
 
 const Track: React.FC<TrackProps> = (props: TrackProps) => {
-    const { id, name, mute, solo, files: sampleFiles } = props;
-    const { addFile, remove, removeFile, setName, toggleMute, toggleSolo } =
-        useTrackAtom(id);
+    const { id, name, mute, solo } = props;
+    const { remove, setName, toggleMute, toggleSolo } = useTrackAtom(id);
     const {
         value: sequencerDialogOpen,
         setTrue: handleOpenSequencerDialog,
@@ -46,19 +43,17 @@ const Track: React.FC<TrackProps> = (props: TrackProps) => {
     const [sequencerValue, setSequencerValue] = useState<
         List<List<FileRecord>>
     >(initializeList(16, List()));
-    const options: Array<SelectMenuItem<FileRecord>> = useMemo(
-        () => FileRecord.toSelectMenuItems(files),
-        [files]
-    );
+    const {
+        value: loadingSamples,
+        setTrue: setLoadingSamplesTrue,
+        setFalse: setLoadingSamplesFalse,
+    } = useBoolean(false);
 
-    const handleFileDeselect = (option: SelectMenuItem<FileRecord>) =>
-        removeFile(option.value);
+    const samples = sequencerValue.flatten().toList() as List<FileRecord>;
 
-    const handleFileSelect = (option: SelectMenuItem<FileRecord>) =>
-        addFile(option.value);
-
-    const handleSamplesLoaded = useCallback((_buffers: ToneAudioBuffer[]) => {},
-    []);
+    useEffect(() => {
+        setLoadingSamplesTrue();
+    }, [sequencerValue, setLoadingSamplesTrue]);
 
     return (
         <Card
@@ -85,23 +80,9 @@ const Track: React.FC<TrackProps> = (props: TrackProps) => {
                         onClick={toggleSolo}
                     />
                 </Tooltip>
-                <SelectMenu
-                    isMultiSelect={true}
-                    options={options}
-                    onDeselect={handleFileDeselect}
-                    onSelect={handleFileSelect}
-                    selected={sampleFiles}
-                    title="Select samples">
-                    <Tooltip content="Track Samples">
-                        <IconButton
-                            icon={MusicIcon}
-                            marginRight={iconMarginRight}
-                        />
-                    </Tooltip>
-                </SelectMenu>
                 <Tooltip content="Sequencer">
                     <IconButton
-                        icon={HeatGridIcon}
+                        icon={loadingSamples ? Spinner : HeatGridIcon}
                         marginRight={iconMarginRight}
                         onClick={handleOpenSequencerDialog}
                     />
@@ -115,21 +96,22 @@ const Track: React.FC<TrackProps> = (props: TrackProps) => {
                     />
                 </Tooltip>
             </Pane>
-            {sequencerDialogOpen && (
+            {sequencerDialogOpen && files != null && (
                 <SequencerDialog
+                    files={files}
                     onChange={setSequencerValue}
                     onClose={handleCloseSequencerDialog}
-                    sampleOptions={FileRecord.toSelectMenuItems(
-                        sampleFiles.toArray()
-                    )}
                     trackId={id}
                     value={sequencerValue}
                 />
             )}
-            <ReactronicaTrack steps={FileRecord.toStepTypes(sequencerValue)}>
+            <ReactronicaTrack
+                mute={mute}
+                solo={solo}
+                steps={FileRecord.toStepTypes(sequencerValue)}>
                 <Instrument
-                    onLoad={handleSamplesLoaded}
-                    samples={FileRecord.toMidiNoteMap(sampleFiles)}
+                    onLoad={setLoadingSamplesFalse}
+                    samples={FileRecord.toMidiNoteMap(samples)}
                     type="sampler"
                 />
             </ReactronicaTrack>

--- a/src/models/track-record.ts
+++ b/src/models/track-record.ts
@@ -22,29 +22,7 @@ class TrackRecord extends BaseRecord(Record(defaultValues)) implements Track {
     constructor(values?: Partial<Track>) {
         values = values ?? defaultValues;
 
-        if (values.files != null) {
-            values.files = List(values.files);
-        }
-
         super(values);
-    }
-
-    public addFile(file: FileRecord): TrackRecord {
-        if (this.files.includes(file)) {
-            return this;
-        }
-
-        return this.merge({ files: this.files.push(file) });
-    }
-
-    public removeFile(file: FileRecord): TrackRecord {
-        if (!this.files.includes(file)) {
-            return this;
-        }
-
-        return this.merge({
-            files: this.files.remove(this.files.indexOf(file)),
-        });
     }
 }
 

--- a/src/utils/hooks/use-track-atom.ts
+++ b/src/utils/hooks/use-track-atom.ts
@@ -1,4 +1,3 @@
-import { FileRecord } from "models/file-record";
 import { TrackRecord } from "models/track-record";
 import { useCallback, useMemo } from "react";
 import { useTracksAtom } from "utils/hooks/use-tracks-atom";
@@ -13,18 +12,8 @@ const useTrackAtom = (id: string) => {
 
     const update = useMemo(() => updateById(id), [id, updateById]);
 
-    const addFile = useCallback(
-        (file: FileRecord) => update((prev) => prev.addFile(file)),
-        [update]
-    );
-
     const setName = useCallback(
         (name: string) => update((prev) => prev.merge({ name })),
-        [update]
-    );
-
-    const removeFile = useCallback(
-        (file: FileRecord) => update((prev) => prev.removeFile(file)),
         [update]
     );
 
@@ -38,9 +27,7 @@ const useTrackAtom = (id: string) => {
 
     return {
         ...track!.toPOJO(),
-        addFile,
         remove,
-        removeFile,
         update,
         setName,
         toggleMute,


### PR DESCRIPTION
Remove intermediary sample selection step from sequencer, add loading state for track when changing samples

TODO: Bubble up loading state to Song/Project so that 'play' functionality is disabled while buffers are being loaded.