### PR TITLE
Fix: keyboard shortcuts executing when they shouldn't be

### DIFF
--- a/src/components/confirmation-dialog.tsx
+++ b/src/components/confirmation-dialog.tsx
@@ -1,4 +1,5 @@
-import { Alert, Dialog, DialogProps, IntentTypes } from "evergreen-ui";
+import { Alert, IntentTypes } from "evergreen-ui";
+import { Dialog, DialogProps } from "components/dialog";
 import React from "react";
 
 interface ConfirmationDialogProps extends DialogProps {

--- a/src/components/dialog.tsx
+++ b/src/components/dialog.tsx
@@ -1,0 +1,22 @@
+import {
+    Dialog as EvergreenDialog,
+    DialogProps as EvergreenDialogProps,
+} from "evergreen-ui";
+
+interface DialogProps extends EvergreenDialogProps {}
+
+const defaultProps: Partial<DialogProps> = {
+    overlayProps: {
+        onClick: (event: React.MouseEvent) => event.stopPropagation(),
+    },
+};
+
+const Dialog: React.FC<DialogProps> = (props: DialogProps) => {
+    const { children } = props;
+    return <EvergreenDialog {...props}>{children}</EvergreenDialog>;
+};
+
+Dialog.defaultProps = defaultProps;
+
+export type { DialogProps };
+export { Dialog };

--- a/src/components/files/file-dialog.tsx
+++ b/src/components/files/file-dialog.tsx
@@ -1,8 +1,9 @@
-import { Dialog, DialogProps, Link, TextInputField } from "evergreen-ui";
+import { Link, TextInputField } from "evergreen-ui";
 import { FileRecord } from "models/file-record";
 import { StorageProviderFileRecord } from "models/storage-provider-file-record";
 import { useState, ChangeEvent } from "react";
 import { useUpdateFile } from "utils/hooks/domain/files/use-update-file";
+import { Dialog, DialogProps } from "components/dialog";
 
 interface FileDialogProps
     extends Pick<DialogProps, "isShown" | "onCloseComplete"> {

--- a/src/components/forms/form-dialog.tsx
+++ b/src/components/forms/form-dialog.tsx
@@ -1,6 +1,7 @@
 import { Form, FormProps } from "components/forms/form";
-import { Button, Dialog, DialogProps, majorScale, Pane } from "evergreen-ui";
+import { Button, majorScale, Pane } from "evergreen-ui";
 import React, { useCallback } from "react";
+import { Dialog, DialogProps } from "components/dialog";
 
 interface FormDialogProps
     extends Omit<DialogProps, "onConfirm">,

--- a/src/components/piano-roll/piano-roll-dialog.tsx
+++ b/src/components/piano-roll/piano-roll-dialog.tsx
@@ -1,5 +1,5 @@
 import { PianoRoll } from "components/piano-roll/piano-roll";
-import { Dialog, DialogProps } from "evergreen-ui";
+import { Dialog, DialogProps } from "components/dialog";
 import { List } from "immutable";
 import { FileRecord } from "models/file-record";
 import { TrackSectionRecord } from "models/track-section-record";

--- a/src/components/sequencer/sequencer-dialog.tsx
+++ b/src/components/sequencer/sequencer-dialog.tsx
@@ -1,5 +1,5 @@
 import { Sequencer } from "components/sequencer/sequencer";
-import { Dialog, DialogProps } from "evergreen-ui";
+import { Dialog, DialogProps } from "components/dialog";
 import { List } from "immutable";
 import { FileRecord } from "models/file-record";
 import { TrackSectionRecord } from "models/track-section-record";

--- a/src/components/sidebar/about-dialog.tsx
+++ b/src/components/sidebar/about-dialog.tsx
@@ -1,8 +1,6 @@
 import {
     Alert,
     Code,
-    Dialog,
-    DialogProps,
     Link,
     majorScale,
     Pane,
@@ -12,6 +10,7 @@ import {
 import React from "react";
 import { formatUpdatedOn } from "utils/date-utils";
 import { useLatestRelease } from "utils/hooks/use-latest-release";
+import { Dialog, DialogProps } from "components/dialog";
 
 enum Environment {
     Development = "Development",

--- a/src/components/workstation/edit-tab.tsx
+++ b/src/components/workstation/edit-tab.tsx
@@ -1,4 +1,5 @@
 import { Menu } from "components/menu/menu";
+import { KeyCode } from "enums/key-code";
 import {
     AnnotationIcon,
     Button,
@@ -8,7 +9,7 @@ import {
     SquareIcon,
 } from "evergreen-ui";
 import React, { useCallback } from "react";
-import { useKey } from "rooks";
+import { useKeys } from "rooks";
 import { useClipboardState } from "utils/hooks/use-clipboard-state";
 
 interface EditTabProps {}
@@ -24,7 +25,7 @@ const EditTab: React.FC<EditTabProps> = (props: EditTabProps) => {
         []
     );
 
-    useKey(["cmd", "d"], duplicateSelected);
+    useKeys([KeyCode.Alt, "d"], duplicateSelected);
 
     return (
         <React.Fragment>
@@ -38,7 +39,7 @@ const EditTab: React.FC<EditTabProps> = (props: EditTabProps) => {
                                 closePopover,
                                 duplicateSelected
                             )}
-                            secondaryText={"⌘D" as any}>
+                            secondaryText={"⌥D" as any}>
                             Duplicate
                         </Menu.Item>
                         <Menu.Item

--- a/src/components/workstation/file-tab.tsx
+++ b/src/components/workstation/file-tab.tsx
@@ -13,7 +13,8 @@ import { useListFiles } from "utils/hooks/domain/files/use-list-files";
 import { useDialog } from "utils/hooks/use-dialog";
 import { ProjectSettingsDialog } from "components/workstation/project-settings-dialog";
 import { isNotNilOrEmpty } from "utils/core-utils";
-import { useKey } from "rooks";
+import { useKeys } from "rooks";
+import { KeyCode } from "enums/key-code";
 
 interface FileTabProps {}
 
@@ -78,8 +79,9 @@ const FileTab: React.FC<FileTabProps> = (props: FileTabProps) => {
         onSuccess: handleSyncSuccess,
     });
 
-    useKey(["cmd", "s"], (event: KeyboardEvent) => {
+    useKeys([KeyCode.Alt, "s"], (event: KeyboardEvent) => {
         event.preventDefault();
+        event.stopPropagation();
         handleSave()();
     });
 

--- a/src/components/workstation/open-project-dialog.tsx
+++ b/src/components/workstation/open-project-dialog.tsx
@@ -1,12 +1,5 @@
 import { ConfirmationDialog } from "components/confirmation-dialog";
-import {
-    Dialog,
-    DialogProps,
-    EmptyState,
-    ProjectsIcon,
-    Spinner,
-    Table,
-} from "evergreen-ui";
+import { EmptyState, ProjectsIcon, Spinner, Table } from "evergreen-ui";
 import { WorkstationStateRecord } from "models/workstation-state-record";
 import React, { useCallback, useState } from "react";
 import { isNilOrEmpty } from "utils/collection-utils";
@@ -15,6 +8,7 @@ import { useBoolean } from "utils/hooks/use-boolean";
 import { useListWorkstations } from "utils/hooks/use-list-workstations";
 import { useTheme } from "utils/hooks/use-theme";
 import { useWorkstationState } from "utils/hooks/use-workstation-state";
+import { Dialog, DialogProps } from "components/dialog";
 
 interface OpenProjectDialogProps
     extends Pick<DialogProps, "isShown" | "onCloseComplete"> {}

--- a/src/components/workstation/project-settings-dialog.tsx
+++ b/src/components/workstation/project-settings-dialog.tsx
@@ -1,12 +1,6 @@
 import { ConfirmButton } from "components/confirm-button";
 import { ErrorMessages } from "constants/error-messages";
-import {
-    Dialog,
-    DialogProps,
-    TextInputField,
-    toaster,
-    TrashIcon,
-} from "evergreen-ui";
+import { TextInputField, toaster, TrashIcon } from "evergreen-ui";
 import { WorkstationStateRecord } from "models/workstation-state-record";
 import React, { useCallback, useState } from "react";
 import { useInput } from "rooks";
@@ -14,6 +8,7 @@ import { isNilOrEmpty } from "utils/core-utils";
 import { useDeleteWorkstationState } from "utils/hooks/use-delete-workstation-state";
 import { useProjectState } from "utils/hooks/use-project-state";
 import { useWorkstationState } from "utils/hooks/use-workstation-state";
+import { Dialog, DialogProps } from "components/dialog";
 
 interface ProjectSettingsDialogProps
     extends Pick<DialogProps, "isShown" | "onCloseComplete"> {}

--- a/src/components/workstation/save-project-dialog.tsx
+++ b/src/components/workstation/save-project-dialog.tsx
@@ -2,8 +2,6 @@ import { ErrorMessages } from "constants/error-messages";
 import {
     Alert,
     BanCircleIcon,
-    Dialog,
-    DialogProps,
     EmptyState,
     Icon,
     Pane,
@@ -19,6 +17,7 @@ import { useGlobalState } from "utils/hooks/use-global-state";
 import { useSyncWorkstationState } from "utils/hooks/use-sync-workstation-state";
 import { useTheme } from "utils/hooks/use-theme";
 import { useWorkstationState } from "utils/hooks/use-workstation-state";
+import { Dialog, DialogProps } from "components/dialog";
 
 interface SaveProjectDialogProps
     extends Pick<DialogProps, "isShown" | "onCloseComplete"> {}

--- a/src/enums/key-code.ts
+++ b/src/enums/key-code.ts
@@ -1,0 +1,5 @@
+enum KeyCode {
+    Alt = "Alt",
+}
+
+export { KeyCode };

--- a/src/utils/hooks/use-clipboard-state.ts
+++ b/src/utils/hooks/use-clipboard-state.ts
@@ -1,7 +1,7 @@
 import { toaster } from "evergreen-ui";
 import { List } from "immutable";
 import { useAtom } from "jotai";
-import { SetStateAction, useCallback } from "react";
+import React, { SetStateAction, useCallback } from "react";
 import { ClipboardItem } from "types/clipboard-item";
 import { SelectedClipboardStateAtom } from "utils/atoms/clipboard-state-atom";
 import {

--- a/src/utils/hooks/use-clipboard-state.ts
+++ b/src/utils/hooks/use-clipboard-state.ts
@@ -1,7 +1,7 @@
 import { toaster } from "evergreen-ui";
 import { List } from "immutable";
 import { useAtom } from "jotai";
-import React, { SetStateAction, useCallback } from "react";
+import { SetStateAction, useCallback } from "react";
 import { ClipboardItem } from "types/clipboard-item";
 import { SelectedClipboardStateAtom } from "utils/atoms/clipboard-state-atom";
 import {

--- a/src/utils/hooks/use-clipboard-state.ts
+++ b/src/utils/hooks/use-clipboard-state.ts
@@ -38,6 +38,8 @@ const useClipboardState = (): UseClipboardStateResult => {
     const duplicateSelected = useCallback(
         (event?: KeyboardEvent) => {
             event?.preventDefault();
+            event?.stopPropagation();
+
             if (selectedState.isEmpty()) {
                 return;
             }


### PR DESCRIPTION
Fixes #47

Fix bug where 'D' and 'S' were executing duplicate/save respectively, because `useKey` is an _either_ not an _and_. 

Additionally, fixed a bug where clicks were propagating through the `Dialog` to the `TrackSectionCard` which would select or deselect the card. All existing `Dialog` components have been swapped with a wrapped version that stops click propagation.