### PR TITLE
Attach event source property to events from wrapped Evergreen Dialog 

### DIFF
--- a/src/components/dialog.tsx
+++ b/src/components/dialog.tsx
@@ -2,12 +2,20 @@ import {
     Dialog as EvergreenDialog,
     DialogProps as EvergreenDialogProps,
 } from "evergreen-ui";
+import React from "react";
+import { attachEventSource } from "utils/event-utils";
 
 interface DialogProps extends EvergreenDialogProps {}
 
 const defaultProps: Partial<DialogProps> = {
+    contentContainerProps: {
+        onClick: attachEventSource("Dialog"),
+    },
+    containerProps: {
+        onClick: attachEventSource("Dialog"),
+    },
     overlayProps: {
-        onClick: (event: React.MouseEvent) => event.stopPropagation(),
+        onClick: attachEventSource("Dialog"),
     },
 };
 

--- a/src/interfaces/traceable-event.ts
+++ b/src/interfaces/traceable-event.ts
@@ -1,0 +1,7 @@
+interface TraceableEvent<E = object, C = any, T = any>
+    extends React.BaseSyntheticEvent<E, C, T> {
+    /** What is the identifier or name of the component where this event originated? */
+    source: string;
+}
+
+export type { TraceableEvent };

--- a/src/utils/event-utils.ts
+++ b/src/utils/event-utils.ts
@@ -1,0 +1,17 @@
+import { TraceableEvent } from "interfaces/traceable-event";
+import React from "react";
+import { isNotNilOrEmpty } from "utils/core-utils";
+
+const attachEventSource =
+    (source: string) => (event: React.BaseSyntheticEvent) => {
+        (event as TraceableEvent).source = source;
+    };
+
+const isEventFromDialog = (event: React.BaseSyntheticEvent): boolean =>
+    isTraceableEvent(event) && event.source === "Dialog";
+
+const isTraceableEvent = (
+    event: React.BaseSyntheticEvent
+): event is TraceableEvent => isNotNilOrEmpty((event as TraceableEvent).source);
+
+export { attachEventSource, isEventFromDialog, isTraceableEvent };

--- a/src/utils/hooks/use-clipboard-state.ts
+++ b/src/utils/hooks/use-clipboard-state.ts
@@ -1,7 +1,7 @@
 import { toaster } from "evergreen-ui";
 import { List } from "immutable";
 import { useAtom } from "jotai";
-import { SetStateAction, useCallback } from "react";
+import React, { SetStateAction, useCallback } from "react";
 import { ClipboardItem } from "types/clipboard-item";
 import { SelectedClipboardStateAtom } from "utils/atoms/clipboard-state-atom";
 import {
@@ -9,6 +9,7 @@ import {
     rebaseIndexes,
     sortBy,
 } from "utils/collection-utils";
+import { isEventFromDialog } from "utils/event-utils";
 import { useWorkstationState } from "utils/hooks/use-workstation-state";
 import { generateIdMap, remapIds } from "utils/id-utils";
 
@@ -17,7 +18,9 @@ interface UseClipboardStateResult {
     deselectItem: (item: ClipboardItem) => void;
     duplicateSelected: (event?: KeyboardEvent) => void;
     isSelected: (value: ClipboardItem) => boolean;
-    onSelect: (item: ClipboardItem) => () => void;
+    onSelect: (
+        item: ClipboardItem
+    ) => (event: React.MouseEvent<HTMLDivElement>) => void;
     selectItem: (item: ClipboardItem) => void;
     selectedState: List<ClipboardItem>;
     setSelectedState: (update: SetStateAction<List<ClipboardItem>>) => void;
@@ -125,7 +128,13 @@ const useClipboardState = (): UseClipboardStateResult => {
     );
 
     const onSelect = useCallback(
-        (item: ClipboardItem) => () => {
+        (item: ClipboardItem) => (event: React.MouseEvent<HTMLDivElement>) => {
+            // A bit of a hack to tell where the event is coming from - but it prevents Dialog clicks
+            // from leaking through and selecting or deselecting the card
+            if (isEventFromDialog(event)) {
+                return;
+            }
+
             if (isSelected(item)) {
                 deselectItem(item);
                 return;


### PR DESCRIPTION
This change will prevent selection of the `TrackSectionCard` while maintaining `SelectMenu` 'click-off' behavior