### PR TITLE
Feature: Preview TrackSection in Sequencer/Piano Roll dialogs

### DIFF
--- a/src/components/piano-roll/piano-key.tsx
+++ b/src/components/piano-roll/piano-key.tsx
@@ -12,8 +12,8 @@ const PianoKey: React.FC<PianoKeyProps> = (props: PianoKeyProps) => {
     const isBlackKey = MidiNoteUtils.isSharp(note);
     const background = isBlackKey ? "black" : "white";
     const textColor = isBlackKey ? "white" : "black";
-    const height = majorScale(3);
-    const width = majorScale(6);
+    const height = majorScale(4);
+    const width = majorScale(4);
     return (
         <Pane
             alignItems="center"
@@ -27,7 +27,7 @@ const PianoKey: React.FC<PianoKeyProps> = (props: PianoKeyProps) => {
             minHeight={height}
             minWidth={width}
             width={width}>
-            <Text color={textColor} size={300}>
+            <Text color={textColor} cursor="default" size={300}>
                 {note}
             </Text>
         </Pane>

--- a/src/components/piano-roll/piano-roll.tsx
+++ b/src/components/piano-roll/piano-roll.tsx
@@ -5,7 +5,14 @@ import { List } from "immutable";
 import { FileRecord } from "models/file-record";
 import { TrackSectionRecord } from "models/track-section-record";
 import { TrackSectionStepRecord } from "models/track-section-step-record";
-import React from "react";
+import React, { useMemo } from "react";
+import { toInstrumentMap } from "utils/file-utils";
+import { toInstrumentStepTypes } from "utils/track-section-step-utils";
+import { Instrument, Track, Song } from "@brandongregoryscott/reactronica";
+import { useBoolean } from "utils/hooks/use-boolean";
+import { useWorkstationState } from "utils/hooks/use-workstation-state";
+import { PlayButton } from "components/workstation/play-button";
+import { useReactronicaState } from "utils/hooks/use-reactronica-state";
 
 interface PianoRollProps {
     file?: FileRecord;
@@ -25,10 +32,33 @@ const PianoRoll: React.FC<PianoRollProps> = (props: PianoRollProps) => {
         trackSection,
         trackSectionSteps,
     } = props;
+    const {
+        state: reactronicaState,
+        onStepPlay,
+        onPlayToggle,
+    } = useReactronicaState({
+        useAtomState: false,
+    });
+    const { value: isPlaying, toggle: toggleIsPlaying } = useBoolean();
+    const { value: isLoading, setFalse: handleLoaded } = useBoolean(true);
+    const { state: workstationState } = useWorkstationState();
+    const { bpm, swing, volume } = workstationState.project;
+    const samples = useMemo(() => toInstrumentMap(file), [file]);
+    const steps = useMemo(
+        () => toInstrumentStepTypes(List.of(trackSection), trackSectionSteps),
+        [trackSection, trackSectionSteps]
+    );
 
     return (
         <React.Fragment>
             <Pane marginBottom={majorScale(1)}>
+                <PlayButton
+                    isLoading={isLoading}
+                    isPlaying={isPlaying}
+                    marginRight={majorScale(1)}
+                    onClick={onPlayToggle}
+                    toggleIsPlaying={toggleIsPlaying}
+                />
                 <StepCountSelectMenu
                     onChange={onStepCountChange}
                     stepCount={stepCount}
@@ -41,12 +71,27 @@ const PianoRoll: React.FC<PianoRollProps> = (props: PianoRollProps) => {
                 width="100%">
                 <PianoSteps
                     file={file}
+                    isPlaying={isPlaying}
                     onChange={onChange}
+                    playingIndex={reactronicaState?.index}
                     stepCount={stepCount}
                     trackSection={trackSection}
                     trackSectionSteps={trackSectionSteps}
                 />
             </Pane>
+            <Song
+                bpm={bpm}
+                isPlaying={isPlaying}
+                swing={swing / 100}
+                volume={volume}>
+                <Track onStepPlay={onStepPlay} steps={steps} subdivision="8n">
+                    <Instrument
+                        onLoad={handleLoaded}
+                        samples={samples}
+                        type="sampler"
+                    />
+                </Track>
+            </Song>
         </React.Fragment>
     );
 };

--- a/src/components/piano-roll/piano-step.tsx
+++ b/src/components/piano-roll/piano-step.tsx
@@ -17,8 +17,8 @@ const PianoStep: React.FC<PianoStepProps> = (props: PianoStepProps) => {
     const { colors } = useTheme();
     const { index, isPlaying, isSelected, note, onClick, isFirst, isLast } =
         props;
-    const height = majorScale(3);
-    const width = majorScale(6);
+    const height = majorScale(4);
+    const width = majorScale(4);
     const handleClick = useCallback(
         () => onClick(index, note),
         [index, note, onClick]

--- a/src/components/piano-roll/piano-step.tsx
+++ b/src/components/piano-roll/piano-step.tsx
@@ -1,30 +1,47 @@
-import { majorScale, Pane } from "evergreen-ui";
+import { Elevation, majorScale, Pane } from "evergreen-ui";
 import { useCallback } from "react";
 import { MidiNote } from "@brandongregoryscott/reactronica";
 import { useTheme } from "utils/hooks/use-theme";
 
 interface PianoStepProps {
     index: number;
+    isFirst: boolean;
+    isLast: boolean;
+    isPlaying: boolean;
     isSelected: boolean;
     note: MidiNote;
     onClick: (index: number, note: MidiNote) => void;
 }
 
 const PianoStep: React.FC<PianoStepProps> = (props: PianoStepProps) => {
-    const theme = useTheme();
-    const { index, isSelected, note, onClick } = props;
+    const { colors } = useTheme();
+    const { index, isPlaying, isSelected, note, onClick, isFirst, isLast } =
+        props;
     const height = majorScale(3);
     const width = majorScale(6);
     const handleClick = useCallback(
         () => onClick(index, note),
         [index, note, onClick]
     );
+
+    const activeProps = isPlaying
+        ? {
+              elevation: 1 as Elevation,
+              transform: "translateY(-4px)",
+          }
+        : {};
+
     return (
         <Pane
+            {...activeProps}
             alignItems="center"
-            background={
-                isSelected ? theme.colors.gray700 : theme.colors.gray300
-            }
+            background={isSelected ? colors.gray700 : colors.gray300}
+            borderBottom={isPlaying && isLast}
+            borderColor={isPlaying ? colors.blue300 : undefined}
+            borderLeft={isPlaying}
+            borderRight={isPlaying}
+            borderTop={isPlaying && isFirst}
+            borderWidth={1}
             cursor="pointer"
             display="flex"
             flexGrow={1}

--- a/src/components/piano-roll/piano-steps.tsx
+++ b/src/components/piano-roll/piano-steps.tsx
@@ -20,7 +20,9 @@ import { isSelected } from "utils/track-section-step-utils";
 
 interface PianoStepsProps {
     file?: FileRecord;
+    isPlaying: boolean;
     onChange: (value: List<TrackSectionStepRecord>) => void;
+    playingIndex?: number;
     stepCount: number;
     trackSection: TrackSectionRecord;
     trackSectionSteps: List<TrackSectionStepRecord>;
@@ -30,8 +32,15 @@ const defaultNoteIndex = MidiNotes.indexOf("C5");
 const indexRange = 12; // Chromatic scale
 
 const PianoSteps: React.FC<PianoStepsProps> = (props: PianoStepsProps) => {
-    const { file, onChange, stepCount, trackSection, trackSectionSteps } =
-        props;
+    const {
+        file,
+        isPlaying,
+        playingIndex,
+        onChange,
+        stepCount,
+        trackSection,
+        trackSectionSteps,
+    } = props;
     const [viewableIndex, setViewableIndex] =
         useState<number>(defaultNoteIndex);
     const handleScaleDown = useCallback(
@@ -76,7 +85,7 @@ const PianoSteps: React.FC<PianoStepsProps> = (props: PianoStepsProps) => {
             MidiNotes.slice(
                 Math.max(viewableIndex, 0),
                 viewableIndex + indexRange
-            ).map((note) => (
+            ).map((note, rowIndex) => (
                 <Pane
                     backgroundColor={theme.colors.gray300}
                     display="flex"
@@ -88,6 +97,9 @@ const PianoSteps: React.FC<PianoStepsProps> = (props: PianoStepsProps) => {
                     {_.range(0, stepCount).map((index: number) => (
                         <PianoStep
                             index={index}
+                            isFirst={rowIndex === 0}
+                            isLast={rowIndex === indexRange - 1}
+                            isPlaying={isPlaying && index === playingIndex}
                             isSelected={isSelected(
                                 trackSectionSteps,
                                 index,
@@ -102,6 +114,8 @@ const PianoSteps: React.FC<PianoStepsProps> = (props: PianoStepsProps) => {
             )),
         [
             handleClick,
+            isPlaying,
+            playingIndex,
             stepCount,
             theme.colors.gray300,
             trackSectionSteps,

--- a/src/components/piano-roll/piano-steps.tsx
+++ b/src/components/piano-roll/piano-steps.tsx
@@ -1,38 +1,33 @@
 import { PianoKey } from "components/piano-roll/piano-key";
 import { PianoStep } from "components/piano-roll/piano-step";
 import { MidiNotes } from "constants/midi-notes";
-import {
-    Pane,
-    IconButton,
-    CaretUpIcon,
-    CaretDownIcon,
-    majorScale,
-} from "evergreen-ui";
+import { Pane } from "evergreen-ui";
 import { List } from "immutable";
 import _ from "lodash";
 import { FileRecord } from "models/file-record";
 import { TrackSectionRecord } from "models/track-section-record";
 import { TrackSectionStepRecord } from "models/track-section-step-record";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo } from "react";
 import { MidiNote } from "@brandongregoryscott/reactronica";
 import { useTheme } from "utils/hooks/use-theme";
 import { isSelected } from "utils/track-section-step-utils";
 
 interface PianoStepsProps {
     file?: FileRecord;
+    indexRange: number;
     isPlaying: boolean;
     onChange: (value: List<TrackSectionStepRecord>) => void;
     playingIndex?: number;
     stepCount: number;
     trackSection: TrackSectionRecord;
     trackSectionSteps: List<TrackSectionStepRecord>;
+    viewableIndex: number;
 }
-
-const defaultNoteIndex = MidiNotes.indexOf("C5");
-const indexRange = 12; // Chromatic scale
 
 const PianoSteps: React.FC<PianoStepsProps> = (props: PianoStepsProps) => {
     const {
+        viewableIndex,
+        indexRange,
         file,
         isPlaying,
         playingIndex,
@@ -41,18 +36,8 @@ const PianoSteps: React.FC<PianoStepsProps> = (props: PianoStepsProps) => {
         trackSection,
         trackSectionSteps,
     } = props;
-    const [viewableIndex, setViewableIndex] =
-        useState<number>(defaultNoteIndex);
-    const handleScaleDown = useCallback(
-        () => setViewableIndex((prev) => prev - indexRange),
-        [setViewableIndex]
-    );
-    const handleScaleUp = useCallback(
-        () => setViewableIndex((prev) => prev + indexRange),
-        [setViewableIndex]
-    );
 
-    const theme = useTheme();
+    const { colors } = useTheme();
     const handleClick = useCallback(
         (index: number, note: MidiNote) => {
             if (isSelected(trackSectionSteps, index, note)) {
@@ -80,14 +65,21 @@ const PianoSteps: React.FC<PianoStepsProps> = (props: PianoStepsProps) => {
         },
         [file, onChange, trackSection, trackSectionSteps]
     );
-    const innerContent = useMemo(
+
+    const notes = useMemo(
         () =>
             MidiNotes.slice(
                 Math.max(viewableIndex, 0),
                 viewableIndex + indexRange
-            ).map((note, rowIndex) => (
+            ),
+        [indexRange, viewableIndex]
+    );
+
+    const innerContent = useMemo(
+        () =>
+            notes.map((note, rowIndex) => (
                 <Pane
-                    backgroundColor={theme.colors.gray300}
+                    backgroundColor={colors.gray300}
                     display="flex"
                     flexDirection="row"
                     flexGrow={1}
@@ -113,29 +105,24 @@ const PianoSteps: React.FC<PianoStepsProps> = (props: PianoStepsProps) => {
                 </Pane>
             )),
         [
+            colors.gray300,
             handleClick,
+            indexRange,
             isPlaying,
+            notes,
             playingIndex,
             stepCount,
-            theme.colors.gray300,
             trackSectionSteps,
-            viewableIndex,
         ]
     );
     return (
-        <React.Fragment>
-            <IconButton
-                icon={CaretUpIcon}
-                onClick={handleScaleDown}
-                width={majorScale(6)}
-            />
+        <Pane
+            display="flex"
+            flexDirection="column"
+            justifyContent="center"
+            marginX="auto">
             {innerContent}
-            <IconButton
-                icon={CaretDownIcon}
-                onClick={handleScaleUp}
-                width={majorScale(6)}
-            />
-        </React.Fragment>
+        </Pane>
     );
 };
 

--- a/src/components/sequencer/sequencer-step.tsx
+++ b/src/components/sequencer/sequencer-step.tsx
@@ -1,14 +1,16 @@
 import { SequencerStepRow } from "components/sequencer/sequencer-step-row";
 import { ConditionalTooltip } from "components/conditional-tooltip";
-import { Card, majorScale } from "evergreen-ui";
+import { Card, Elevation, majorScale } from "evergreen-ui";
 import { List } from "immutable";
 import { FileRecord } from "models/file-record";
 import { TrackSectionStepRecord } from "models/track-section-step-record";
 import { TrackSectionRecord } from "models/track-section-record";
+import { useTheme } from "utils/hooks/use-theme";
 
 interface SequencerStepProps {
     files: List<FileRecord>;
     index: number;
+    isPlaying: boolean;
     onChange: (index: number, steps: List<TrackSectionStepRecord>) => void;
     selected: List<FileRecord>;
     trackSection: TrackSectionRecord;
@@ -20,7 +22,9 @@ const maxCount = 4;
 const SequencerStep: React.FC<SequencerStepProps> = (
     props: SequencerStepProps
 ) => {
-    const { index, files, onChange, selected, trackSection, value } = props;
+    const { index, isPlaying, files, onChange, selected, trackSection, value } =
+        props;
+    const { colors } = useTheme();
     const hasSamples = !selected.isEmpty();
     const handleAdd = () => {
         if (
@@ -57,12 +61,21 @@ const SequencerStep: React.FC<SequencerStepProps> = (
         onChange(index, value.remove(value.indexOf(step)));
     };
 
+    const activeProps = isPlaying
+        ? {
+              elevation: 1 as Elevation,
+              transform: "translateY(-4px)",
+          }
+        : {};
+
     return (
         <ConditionalTooltip
             content="Select one or more samples to drop in"
             shouldRender={!hasSamples && value.isEmpty()}>
             <Card
+                {...activeProps}
                 border={true}
+                borderColor={isPlaying ? colors.blue200 : undefined}
                 cursor={hasSamples ? "pointer" : "not-allowed"}
                 height={majorScale(12)}
                 hoverElevation={1}

--- a/src/components/sequencer/sequencer.tsx
+++ b/src/components/sequencer/sequencer.tsx
@@ -1,14 +1,32 @@
 import { SequencerStep } from "components/sequencer/sequencer-step";
-import { Button, majorScale, Pane } from "evergreen-ui";
+import {
+    Button,
+    IconButton,
+    majorScale,
+    Pane,
+    PauseIcon,
+    PlayIcon,
+} from "evergreen-ui";
 import _ from "lodash";
 import { List } from "immutable";
 import { FileRecord } from "models/file-record";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import pluralize from "pluralize";
 import { TrackSectionStepRecord } from "models/track-section-step-record";
 import { TrackSectionRecord } from "models/track-section-record";
 import { StepCountSelectMenu } from "components/step-count-select-menu";
 import { FileSelectMenu } from "components/file-select-menu";
+import {
+    Instrument,
+    Track,
+    Song,
+    StepNoteType,
+} from "@brandongregoryscott/reactronica";
+import { toSequencerMap } from "utils/file-utils";
+import { toSequencerStepTypes } from "utils/track-section-step-utils";
+import { useBoolean } from "utils/hooks/use-boolean";
+import { useWorkstationState } from "utils/hooks/use-workstation-state";
+import { ReactronicaState } from "interfaces/reactronica-state";
 
 interface SequencerProps {
     files: List<FileRecord>;
@@ -19,15 +37,29 @@ interface SequencerProps {
     trackSectionSteps: List<TrackSectionStepRecord>;
 }
 
+const buttonMarginRight = majorScale(1);
+
 const Sequencer: React.FC<SequencerProps> = (props: SequencerProps) => {
     const {
         onStepChange,
         onStepCountChange,
         files,
         stepCount,
-        trackSectionSteps: steps,
+        trackSectionSteps,
         trackSection,
     } = props;
+    const [reactronicaState, setReactronicaState] = useState<ReactronicaState>({
+        notes: [],
+        index: 0,
+    });
+    const handleStepPlay = useCallback(
+        (notes: StepNoteType[], index: number) =>
+            setReactronicaState({ notes, index }),
+        []
+    );
+    const { value: isPlaying, toggle: toggleIsPlaying } = useBoolean();
+    const { state: workstationState } = useWorkstationState();
+    const { bpm, swing, volume } = workstationState.project;
     const [selected, setSelected] = useState<List<FileRecord>>(List());
 
     const handleDeselect = useCallback(
@@ -46,16 +78,32 @@ const Sequencer: React.FC<SequencerProps> = (props: SequencerProps) => {
         [setSelected]
     );
 
+    const samples = useMemo(() => toSequencerMap(files), [files]);
+    const steps = useMemo(
+        () =>
+            toSequencerStepTypes(
+                List.of(trackSection),
+                trackSectionSteps,
+                files
+            ),
+        [files, trackSection, trackSectionSteps]
+    );
+
     return (
         <Pane>
             <Pane marginBottom={majorScale(1)}>
+                <IconButton
+                    icon={isPlaying ? PauseIcon : PlayIcon}
+                    marginRight={buttonMarginRight}
+                    onClick={toggleIsPlaying}
+                />
                 <FileSelectMenu
                     isMultiSelect={true}
                     onDeselect={handleDeselect}
                     onSelect={handleSelect}
                     selected={selected}
                     title="Current Samples">
-                    <Button marginRight={majorScale(1)}>
+                    <Button marginRight={buttonMarginRight}>
                         {selected.count()}{" "}
                         {pluralize("Sample", selected.count())}
                     </Button>
@@ -75,17 +123,32 @@ const Sequencer: React.FC<SequencerProps> = (props: SequencerProps) => {
                     <SequencerStep
                         files={files}
                         index={index}
+                        isPlaying={
+                            isPlaying && reactronicaState.index === index
+                        }
                         key={index}
                         onChange={onStepChange}
                         selected={selected}
                         trackSection={trackSection}
-                        value={steps.filter(
+                        value={trackSectionSteps.filter(
                             (trackSectionStep) =>
                                 trackSectionStep.index === index
                         )}
                     />
                 ))}
             </Pane>
+            <Song
+                bpm={bpm}
+                isPlaying={isPlaying}
+                swing={swing / 100}
+                volume={volume}>
+                <Track
+                    onStepPlay={handleStepPlay}
+                    steps={steps}
+                    subdivision="8n">
+                    <Instrument samples={samples} type="sampler" />
+                </Track>
+            </Song>
         </Pane>
     );
 };

--- a/src/components/workstation/play-button.tsx
+++ b/src/components/workstation/play-button.tsx
@@ -1,0 +1,46 @@
+import {
+    IconButton,
+    IconButtonProps,
+    PauseIcon,
+    PlayIcon,
+    Spinner,
+} from "evergreen-ui";
+import { useCallback, useMemo } from "react";
+
+interface PlayButtonProps extends Omit<IconButtonProps, "icon" | "onClick"> {
+    isPlaying: boolean;
+    onClick?: (isPlaying: boolean) => void;
+    toggleIsPlaying: () => void;
+}
+
+const PlayButton: React.FC<PlayButtonProps> = (props: PlayButtonProps) => {
+    const {
+        isLoading,
+        isPlaying,
+        toggleIsPlaying,
+        onClick,
+        ...iconButtonProps
+    } = props;
+    const handleClick = useCallback(() => {
+        onClick?.(isPlaying);
+        toggleIsPlaying();
+    }, [isPlaying, onClick, toggleIsPlaying]);
+
+    const icon = useMemo(() => {
+        if (isLoading) {
+            return <Spinner />;
+        }
+
+        return isPlaying ? PauseIcon : PlayIcon;
+    }, [isLoading, isPlaying]);
+    return (
+        <IconButton
+            {...iconButtonProps}
+            disabled={isLoading}
+            icon={icon}
+            onClick={handleClick}
+        />
+    );
+};
+
+export { PlayButton };

--- a/src/components/workstation/song-controls.tsx
+++ b/src/components/workstation/song-controls.tsx
@@ -2,8 +2,6 @@ import {
     IconButton,
     minorScale,
     Pane,
-    PauseIcon,
-    PlayIcon,
     VolumeOffIcon,
     VolumeUpIcon,
     Label,
@@ -18,7 +16,7 @@ import { useBoolean } from "utils/hooks/use-boolean";
 import { Song as ReactronicaSong } from "@brandongregoryscott/reactronica";
 import { useProjectState } from "utils/hooks/use-project-state";
 import { isNilOrEmpty } from "utils/core-utils";
-import { useReactronicaState } from "utils/hooks/use-reactronica-state";
+import { PlayButton } from "components/workstation/play-button";
 
 interface SongControlsProps {}
 
@@ -29,7 +27,6 @@ const SongControls: React.FC<SongControlsProps> = (
 ) => {
     const { children } = props;
     const { state: project, setCurrentState } = useProjectState();
-    const { onPause } = useReactronicaState();
     const { bpm, swing, volume } = project;
     const { value: isMuted, toggle: toggleIsMuted } = useBoolean(false);
     const { value: isPlaying, toggle: toggleIsPlaying } = useBoolean(false);
@@ -80,14 +77,6 @@ const SongControls: React.FC<SongControlsProps> = (
         [setCurrentState]
     );
 
-    const handlePlayingClick = useCallback(() => {
-        if (isPlaying) {
-            onPause();
-        }
-
-        toggleIsPlaying();
-    }, [isPlaying, onPause, toggleIsPlaying]);
-
     return (
         <Pane>
             <Heading marginBottom={majorScale(1)} size={500}>
@@ -98,10 +87,10 @@ const SongControls: React.FC<SongControlsProps> = (
                 display="flex"
                 flexDirection="row"
                 marginBottom={majorScale(2)}>
-                <IconButton
-                    icon={isPlaying ? PauseIcon : PlayIcon}
+                <PlayButton
+                    isPlaying={isPlaying}
                     marginRight={marginRight}
-                    onClick={handlePlayingClick}
+                    toggleIsPlaying={toggleIsPlaying}
                 />
                 <IconButton
                     icon={isMuted ? VolumeOffIcon : VolumeUpIcon}

--- a/src/utils/hooks/use-reactronica-state.ts
+++ b/src/utils/hooks/use-reactronica-state.ts
@@ -1,26 +1,55 @@
 import { ReactronicaState } from "interfaces/reactronica-state";
 import { SetStateAction, useAtom } from "jotai";
-import { useCallback } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { StepNoteType } from "@brandongregoryscott/reactronica";
 import { ReactronicaStateAtom } from "utils/atoms/reactronica-atom";
 
+interface UseReactronicaStateOptions {
+    /** When true, uses shared `ReactronicaStateAtom`. Otherwise, creates a local state value */
+    useAtomState?: boolean;
+}
+
 interface UseReactronicaStateResult {
-    onPause: () => void;
+    onPlayToggle: (isPlaying: boolean) => void;
     onStepPlay: (notes: StepNoteType[], index: number) => void;
-    setState: (update?: SetStateAction<ReactronicaState | undefined>) => void;
+    setState: (update: SetStateAction<ReactronicaState | undefined>) => void;
     state: ReactronicaState | undefined;
 }
 
-const useReactronicaState = (): UseReactronicaStateResult => {
-    const [state, setState] = useAtom(ReactronicaStateAtom);
+const useReactronicaState = (
+    options?: UseReactronicaStateOptions
+): UseReactronicaStateResult => {
+    const { useAtomState = true } = options ?? {};
+    const [atomState, setAtomState] = useAtom(ReactronicaStateAtom);
+    const [localState, setLocalState] = useState<
+        ReactronicaState | undefined
+    >();
+    const state = useMemo(
+        () => (useAtomState ? atomState : localState),
+        [atomState, localState, useAtomState]
+    );
+    const setState = useMemo(
+        () => (useAtomState ? setAtomState : setLocalState),
+        [setAtomState, setLocalState, useAtomState]
+    );
 
     const onPause = useCallback(() => setState(undefined), [setState]);
     const onStepPlay = useCallback(
         (notes: StepNoteType[], index: number) => setState({ notes, index }),
         [setState]
     );
+    const onPlayToggle = useCallback(
+        (isPlaying: boolean) => {
+            if (!isPlaying) {
+                return;
+            }
 
-    return { state, setState, onPause, onStepPlay };
+            onPause();
+        },
+        [onPause]
+    );
+
+    return { state, setState, onStepPlay, onPlayToggle };
 };
 
 export { useReactronicaState };


### PR DESCRIPTION
Resolves #41 

Wires up the ability to play the snippet of the track you're editing within the context of the dialog, i.e. `SequencerDialog` or `PianoRollDialog`. Some minor styling changes to reduce width of piano steps and bring the scale up/scale down buttons up to the same level as the other controls.
