### PR TITLE
Misc: Production issues/improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "beets",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "beets",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "dependencies": {
                 "@brandongregoryscott/reactronica": "0.7.1",
                 "@octokit/rest": "18.12.0",

--- a/package.json
+++ b/package.json
@@ -96,5 +96,5 @@
         "start": "react-scripts start",
         "test": "react-scripts test"
     },
-    "version": "1.4.0"
+    "version": "1.5.0"
 }

--- a/src/components/pages/workstation-page.tsx
+++ b/src/components/pages/workstation-page.tsx
@@ -82,7 +82,12 @@ const WorkstationPage: React.FC<WorkstationPageProps> = (
     );
 
     useEffect(() => {
-        if (isLoadingFiles || isLoadingWorkstations) {
+        if (
+            isLoadingFiles ||
+            isLoadingWorkstations ||
+            project.isPersisted() ||
+            project.isDemo()
+        ) {
             return;
         }
 
@@ -105,6 +110,7 @@ const WorkstationPage: React.FC<WorkstationPageProps> = (
         files,
         isLoadingFiles,
         isLoadingWorkstations,
+        project,
         setState,
         user,
         workstations,

--- a/src/components/pages/workstation-page.tsx
+++ b/src/components/pages/workstation-page.tsx
@@ -85,8 +85,8 @@ const WorkstationPage: React.FC<WorkstationPageProps> = (
         if (
             isLoadingFiles ||
             isLoadingWorkstations ||
-            project.isPersisted() ||
-            project.isDemo()
+            (project.isPersisted() && user != null) ||
+            (project.isDemo() && user == null)
         ) {
             return;
         }

--- a/src/components/piano-roll/piano-roll.tsx
+++ b/src/components/piano-roll/piano-roll.tsx
@@ -26,6 +26,7 @@ import { PlayButton } from "components/workstation/play-button";
 import { useReactronicaState } from "utils/hooks/use-reactronica-state";
 import { MidiNotes } from "constants/midi-notes";
 import { InstrumentRecord } from "models/instrument-record";
+import { MidiNoteUtils } from "utils/midi-note-utils";
 
 interface PianoRollProps {
     file?: FileRecord;
@@ -38,7 +39,7 @@ interface PianoRollProps {
 }
 
 const buttonMarginRight = majorScale(1);
-const defaultNoteIndex = MidiNotes.indexOf("C5");
+const defaultNoteIndex = MidiNotes.indexOf(MidiNoteUtils.defaultNote);
 const indexRange = 12; // Chromatic scale
 
 const PianoRoll: React.FC<PianoRollProps> = (props: PianoRollProps) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,6 @@ const queryClient = new QueryClient({
     defaultOptions: {
         queries: {
             refetchOnWindowFocus: false,
-            staleTime: 1000 * 60 * 5,
         },
     },
 });

--- a/src/models/project-record.ts
+++ b/src/models/project-record.ts
@@ -5,6 +5,7 @@ import { AuditableRecord } from "models/auditable-record";
 import { AuditableDefaultValues } from "constants/auditable-default-values";
 import { RecordParams } from "types/record-params";
 import { generateId } from "utils/id-utils";
+import { WorkstationStateRecord } from "models/workstation-state-record";
 
 const defaultValues = makeDefaultValues<Project>({
     ...AuditableDefaultValues,
@@ -30,6 +31,10 @@ class ProjectRecord
         }
 
         super(values);
+    }
+
+    public isDemo(): boolean {
+        return this.id.includes(WorkstationStateRecord.demoId);
     }
 }
 

--- a/src/models/workstation-state-record.ts
+++ b/src/models/workstation-state-record.ts
@@ -18,6 +18,7 @@ import {
 } from "utils/collection-utils";
 import { makeDefaultValues } from "utils/core-utils";
 import { findKick, findHat, findOpenHat, findSnare } from "utils/file-utils";
+import { MidiNoteUtils } from "utils/midi-note-utils";
 import { getByTrackSection } from "utils/track-section-step-utils";
 import { getByTrack } from "utils/track-section-utils";
 
@@ -88,7 +89,7 @@ class WorkstationStateRecord
             index: 0,
             file_id: wavyPad?.id,
             track_section_id: padTrackSection.id,
-            note: "C5",
+            note: MidiNoteUtils.defaultNote,
         });
 
         const kickSteps = [

--- a/src/models/workstation-state-record.ts
+++ b/src/models/workstation-state-record.ts
@@ -45,6 +45,8 @@ class WorkstationStateRecord
     extends BaseRecord(Record(defaultValues))
     implements WorkstationState
 {
+    public static demoId: string = demoId;
+
     public static demo(files?: List<FileRecord>): WorkstationStateRecord {
         const instruments = buildDemoInstruments(files);
         const wavyPad = instruments.find(
@@ -248,7 +250,7 @@ class WorkstationStateRecord
     }
 
     public isDemo(): boolean {
-        return this.project.id.includes(demoId);
+        return this.project.isDemo();
     }
 }
 

--- a/src/utils/midi-note-utils.ts
+++ b/src/utils/midi-note-utils.ts
@@ -1,6 +1,6 @@
 import { MidiNote } from "@brandongregoryscott/reactronica";
 
-const defaultNote: MidiNote = "C5";
+const defaultNote: MidiNote = "C4";
 
 const MidiNoteUtils = {
     defaultNote,


### PR DESCRIPTION
- Sets root note to C4, which I believe should be the "default" sample note which retains original pitch
- Fixes a bug in `WorkstationPage` where the state is overwritten when adding a new track (oops)
- Additionally, workstation state should be preserved when navigating between library/home :tada: