### PR TITLE
Prevent selection duplication while playing

### DIFF
--- a/src/components/pages/workstation-page.tsx
+++ b/src/components/pages/workstation-page.tsx
@@ -9,7 +9,7 @@ import {
     Tooltip,
 } from "evergreen-ui";
 import { WorkstationStateRecord } from "models/workstation-state-record";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useListFiles } from "utils/hooks/domain/files/use-list-files";
 import { useWorkstationState } from "utils/hooks/use-workstation-state";
 import { useListWorkstations } from "utils/hooks/use-list-workstations";
@@ -64,14 +64,13 @@ const WorkstationPage: React.FC<WorkstationPageProps> = (
     const { globalState } = useGlobalState();
     const { resultObject: files = List(), isLoading: isLoadingFiles } =
         useListFiles();
-    const { resultObject: instrumentsArray, isLoading: isLoadingInstruments } =
-        useListInstruments();
+    const {
+        resultObject: instruments = List(),
+        isLoading: isLoadingInstruments,
+    } = useListInstruments({ files });
     const { resultObject: workstations, isLoading: isLoadingWorkstations } =
         useListWorkstations();
-    const instruments = useMemo(
-        () => List(instrumentsArray ?? []),
-        [instrumentsArray]
-    );
+
     // Unfortunate hack to prevent infinite loading issue for initial render when a staleTime
     // is set: https://github.com/tannerlinsley/react-query/issues/1657
     const [hookTimedOut, setHookTimedOut] = useState(false);

--- a/src/components/song-composition/song-composition.tsx
+++ b/src/components/song-composition/song-composition.tsx
@@ -30,7 +30,12 @@ const SongComposition: React.FC<SongCompositionProps> = (
             swing={swing / 100}
             volume={volume}>
             {tracks.map((track) => (
-                <Track files={files} instruments={instruments} track={track} />
+                <Track
+                    files={files}
+                    instruments={instruments}
+                    key={track.id}
+                    track={track}
+                />
             ))}
         </Reactronica.Song>
     );

--- a/src/components/tracks/track-card/playing-track-card.tsx
+++ b/src/components/tracks/track-card/playing-track-card.tsx
@@ -63,7 +63,7 @@ const PlayingTrackCard: React.FC<PlayingTrackCardProps> = (
     );
 
     return (
-        <Pane marginBottom={majorScale(2)} marginTop={majorScale(2)}>
+        <Pane marginY={majorScale(2)}>
             <Pane alignItems="center" display="flex" flexDirection="row">
                 <Card
                     alignItems="flex-start"

--- a/src/components/tracks/track-card/track-card.tsx
+++ b/src/components/tracks/track-card/track-card.tsx
@@ -92,15 +92,16 @@ const TrackCard: React.FC<TrackCardProps> = (props: TrackCardProps) => {
     return (
         <Pane
             marginBottom={
-                index === tracks.count() - 1 ? undefined : majorScale(1)
+                index === tracks.count() - 1 ? -majorScale(1) : undefined
             }
-            marginTop={index === 0 ? undefined : majorScale(1)}>
+            marginTop={index === 0 ? -majorScale(1) : undefined}>
             <Draggable draggableId={track.id} index={track.index}>
                 {(provided) => (
                     <Pane
                         alignItems="center"
                         display="flex"
                         flexDirection="row"
+                        marginY={majorScale(1)}
                         ref={provided.innerRef}
                         {...provided.draggableProps}>
                         <Card

--- a/src/components/tracks/track-section-card/playing-track-section-card.tsx
+++ b/src/components/tracks/track-section-card/playing-track-section-card.tsx
@@ -45,7 +45,7 @@ const PlayingTrackSectionCard: React.FC<PlayingTrackSectionCardProps> = (
     });
     const { state: reactronicaState } = useReactronicaState();
 
-    const { isSelected, onSelect } = useClipboardState();
+    const { isSelected } = useClipboardState();
 
     const { state: trackSectionSteps } = useTrackSectionStepsState({
         trackSectionId: trackSection.id,
@@ -65,7 +65,6 @@ const PlayingTrackSectionCard: React.FC<PlayingTrackSectionCardProps> = (
             display="flex"
             flexDirection="row"
             height={majorScale(10)}
-            onClick={onSelect(trackSection)}
             paddingLeft={isFirst ? majorScale(1) : undefined}
             paddingRight={isLast ? majorScale(1) : undefined}
             paddingY={majorScale(1)}>

--- a/src/components/workstation/edit-tab.tsx
+++ b/src/components/workstation/edit-tab.tsx
@@ -10,12 +10,16 @@ import {
 import React, { useCallback } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useClipboardState } from "utils/hooks/use-clipboard-state";
+import { useReactronicaState } from "utils/hooks/use-reactronica-state";
 
 interface EditTabProps {}
 
 const EditTab: React.FC<EditTabProps> = (props: EditTabProps) => {
     const { selectedState, clearSelected, duplicateSelected } =
         useClipboardState();
+    const {
+        state: { isPlaying },
+    } = useReactronicaState();
     const handleClick = useCallback(
         (closePopover: () => void, callback: () => void) => () => {
             callback();
@@ -24,7 +28,7 @@ const EditTab: React.FC<EditTabProps> = (props: EditTabProps) => {
         []
     );
 
-    useHotkeys("cmd+d", duplicateSelected, [selectedState]);
+    useHotkeys("cmd+d", duplicateSelected, [isPlaying, selectedState]);
 
     return (
         <React.Fragment>

--- a/src/models/workstation-state-record.ts
+++ b/src/models/workstation-state-record.ts
@@ -14,6 +14,7 @@ import { buildDemoInstruments } from "utils/build-demo-instruments";
 import {
     diffDeletedEntities,
     diffUpdatedEntities,
+    rebaseIndexes,
     sortBy,
 } from "utils/collection-utils";
 import { makeDefaultValues } from "utils/core-utils";
@@ -141,7 +142,7 @@ class WorkstationStateRecord
 
         return new WorkstationStateRecord({
             project,
-            tracks: List.of(drumTrack, padTrack),
+            tracks: rebaseIndexes(List.of(drumTrack, padTrack)),
             trackSections: List.of(drumTrackSection, padTrackSection),
             trackSectionSteps: List.of(
                 ...kickSteps,

--- a/src/utils/hooks/use-clipboard-state.ts
+++ b/src/utils/hooks/use-clipboard-state.ts
@@ -10,6 +10,7 @@ import {
     sortBy,
 } from "utils/collection-utils";
 import { isEventFromDialog } from "utils/event-utils";
+import { useReactronicaState } from "utils/hooks/use-reactronica-state";
 import { useWorkstationState } from "utils/hooks/use-workstation-state";
 import { generateIdMap, remapIds } from "utils/id-utils";
 
@@ -26,7 +27,12 @@ interface UseClipboardStateResult {
     setSelectedState: (update: SetStateAction<List<ClipboardItem>>) => void;
 }
 
+const IS_PLAYING_ERROR_TOAST_ID = "IS_PLAYING";
+
 const useClipboardState = (): UseClipboardStateResult => {
+    const {
+        state: { isPlaying },
+    } = useReactronicaState();
     const { state, setCurrentState: setCurrentWorkstationState } =
         useWorkstationState();
     const [selectedState, setSelectedState] = useAtom(
@@ -43,6 +49,14 @@ const useClipboardState = (): UseClipboardStateResult => {
             event?.preventDefault();
 
             if (selectedState.isEmpty()) {
+                return;
+            }
+
+            if (isPlaying) {
+                toaster.danger(
+                    "You can't duplicate Track Sections while the project is playing!",
+                    { id: IS_PLAYING_ERROR_TOAST_ID }
+                );
                 return;
             }
 
@@ -92,6 +106,7 @@ const useClipboardState = (): UseClipboardStateResult => {
         },
         [
             duplicationMessage,
+            isPlaying,
             selectedState,
             setCurrentWorkstationState,
             setSelectedState,


### PR DESCRIPTION
Fixes the following issues:

- Track Sections should not be duplicated while playing (most of the workstation aside from playing controls should be 'read-only')
- Fixes a bug where the demo project for unauthenticated users was breaking because `files` were not being passed into the `useListInstruments` hook to associate the two. Additionally there was some memoization that reduced recalculation of hook values.
- Fixes spacing issues between the playing/draggable versions of `TrackCard` (also adds explicit indexes for the demo project `Tracks`)