### PR TITLE
Update deselectItem function to filter by id vs. value comparison 

### DIFF
--- a/src/utils/hooks/use-clipboard-state.ts
+++ b/src/utils/hooks/use-clipboard-state.ts
@@ -130,14 +130,9 @@ const useClipboardState = (): UseClipboardStateResult => {
 
     const deselectItem = useCallback(
         (item: ClipboardItem) =>
-            setSelectedState((prev) => {
-                const index = prev.indexOf(item);
-                if (index < 0) {
-                    return prev;
-                }
-
-                return prev.remove(index);
-            }),
+            setSelectedState((prev) =>
+                prev.filter((selectedItem) => selectedItem.id !== item.id)
+            ),
         [setSelectedState]
     );
 


### PR DESCRIPTION
Resolves #69 

Since the item changes after being moved (index is updated), `List.indexOf(item)` returns false and the item is not deselected. Performing a filter on the list by id should always remove the item if it exists in the list.