### PR TITLE
Allow LibraryPage to scroll when content overflows

### DIFF
--- a/src/components/layouts/library-layout.tsx
+++ b/src/components/layouts/library-layout.tsx
@@ -34,19 +34,21 @@ const LibraryLayout: React.FC<LibraryLayoutProps> = (
     );
 
     return (
-        <Pane marginLeft={majorScale(2)} marginTop={majorScale(2)}>
-            <TabNavigation>
-                {tabs.map((tab) => (
-                    <Tab
-                        isSelected={isTabSelected(tab)}
-                        key={tab}
-                        onSelect={handleClick(tab)}>
-                        {tab}
-                    </Tab>
-                ))}
-            </TabNavigation>
-            <Pane marginTop={majorScale(2)}>
-                <NestedRoutes route={route} />
+        <Pane height="100vh" overflow="auto">
+            <Pane marginLeft={majorScale(2)} marginTop={majorScale(2)}>
+                <TabNavigation>
+                    {tabs.map((tab) => (
+                        <Tab
+                            isSelected={isTabSelected(tab)}
+                            key={tab}
+                            onSelect={handleClick(tab)}>
+                            {tab}
+                        </Tab>
+                    ))}
+                </TabNavigation>
+                <Pane marginBottom={majorScale(2)} marginTop={majorScale(2)}>
+                    <NestedRoutes route={route} />
+                </Pane>
             </Pane>
         </Pane>
     );

--- a/src/components/pages/files-page.tsx
+++ b/src/components/pages/files-page.tsx
@@ -20,11 +20,15 @@ const FilesPage: React.FC<FilesPageProps> = (props: FilesPageProps) => {
     const theme = useTheme();
     return (
         <React.Fragment>
-            <FileList bucketName={BucketName.Samples} />
+            {globalState.isAuthenticated() && (
+                <React.Fragment>
+                    <Pane marginBottom={majorScale(2)}>
+                        <FileUpload bucketName={BucketName.Samples} />
+                    </Pane>
+                    <FileList bucketName={BucketName.Samples} />
+                </React.Fragment>
+            )}
             <Pane marginTop={majorScale(1)}>
-                {globalState.isAuthenticated() && (
-                    <FileUpload bucketName={BucketName.Samples} />
-                )}
                 {!globalState.isAuthenticated() && (
                     <Pane maxWidth={majorScale(60)}>
                         <EmptyState


### PR DESCRIPTION
Fix #78 

Additionally, moves the `FileUpload` component above the list. This should be a holdover until I work on a more advanced page described in #39 

![image](https://user-images.githubusercontent.com/11774799/152783459-2e426547-7347-450c-8d83-4a7c5d155ebd.png)
