### PR TITLE
Update app layout to better allow for scrolling

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,4 @@
 import { NestedRoutes } from "components/nested-routes";
-import { Pane } from "evergreen-ui";
 import { useEffect } from "react";
 import { useQueryClient } from "react-query";
 import { BrowserRouter } from "react-router-dom";
@@ -12,12 +11,10 @@ const App: React.FC = () => {
     useEffect(() => queryClient.clear(), [queryClient, user]);
 
     return (
-        <Pane height="100vh" overflowY="hidden">
-            <BrowserRouter>
-                <NestedRoutes routes={Routes} />
-            </BrowserRouter>
-        </Pane>
+        <BrowserRouter>
+            <NestedRoutes routes={Routes} />
+        </BrowserRouter>
     );
 };
 
-export default App;
+export { App };

--- a/src/components/layouts/application-layout.tsx
+++ b/src/components/layouts/application-layout.tsx
@@ -13,7 +13,7 @@ const ApplicationLayout: React.FC<ApplicationLayoutProps> = (
     useSubscribeToAuthStatus();
 
     return (
-        <Pane display="flex" flexDirection="row" height="100%">
+        <Pane display="flex" flexDirection="row" height="100%" width="100%">
             <SidebarNavigation />
             <NestedRoutes route={route} />
         </Pane>

--- a/src/components/layouts/application-layout.tsx
+++ b/src/components/layouts/application-layout.tsx
@@ -15,9 +15,7 @@ const ApplicationLayout: React.FC<ApplicationLayoutProps> = (
     return (
         <Pane display="flex" flexDirection="row" height="100%">
             <SidebarNavigation />
-            <Pane overflowX="auto">
-                <NestedRoutes route={route} />
-            </Pane>
+            <NestedRoutes route={route} />
         </Pane>
     );
 };

--- a/src/components/layouts/application-layout.tsx
+++ b/src/components/layouts/application-layout.tsx
@@ -13,11 +13,9 @@ const ApplicationLayout: React.FC<ApplicationLayoutProps> = (
     useSubscribeToAuthStatus();
 
     return (
-        <Pane display="flex" flexDirection="row">
-            <Pane>
-                <SidebarNavigation />
-            </Pane>
-            <Pane width="100%">
+        <Pane display="flex" flexDirection="row" height="100%">
+            <SidebarNavigation />
+            <Pane overflowX="auto">
                 <NestedRoutes route={route} />
             </Pane>
         </Pane>

--- a/src/components/layouts/workstation-layout.tsx
+++ b/src/components/layouts/workstation-layout.tsx
@@ -10,7 +10,7 @@ const WorkstationLayout: React.FC<WorkstationLayoutProps> = (
 ) => {
     const { route } = props;
     return (
-        <Pane width="100%">
+        <Pane width="100%" height="100%">
             <WorkstationTabs />
             <NestedRoutes route={route} />
         </Pane>

--- a/src/components/pages/login-page.tsx
+++ b/src/components/pages/login-page.tsx
@@ -1,5 +1,5 @@
 import { LoginOrRegister } from "components/login-or-register";
-import { majorScale, Pane } from "evergreen-ui";
+import { Pane } from "evergreen-ui";
 import { RouteProps } from "interfaces/route-props";
 
 interface LoginPageProps extends RouteProps {}
@@ -10,8 +10,8 @@ const LoginPage: React.FC<LoginPageProps> = (props: LoginPageProps) => {
             alignItems="center"
             display="flex"
             flexDirection="column"
-            height={`calc(100% - ${majorScale(12)}px)`}
-            justifyContent="center">
+            justifyContent="center"
+            width="100%">
             <LoginOrRegister initialShowRegister={false} />
         </Pane>
     );

--- a/src/components/pages/workstation-page.tsx
+++ b/src/components/pages/workstation-page.tsx
@@ -175,7 +175,17 @@ const WorkstationPage: React.FC<WorkstationPageProps> = (
 
     return (
         <Pane height="100%" marginTop={margin} width="100%">
-            {renderSpinner && <Spinner />}
+            {renderSpinner && (
+                <Pane
+                    alignItems="center"
+                    display="flex"
+                    flexDirection="column"
+                    height="100%"
+                    justifyContent="center"
+                    width="100%">
+                    <Spinner />
+                </Pane>
+            )}
             {renderControls && (
                 <Pane height="100%" marginLeft={margin} width="100%">
                     <SongControls />

--- a/src/components/pages/workstation-page.tsx
+++ b/src/components/pages/workstation-page.tsx
@@ -33,7 +33,6 @@ import { DraggableTrackList } from "components/tracks/track-list/draggable-track
 import { SongComposition } from "components/song-composition/song-composition";
 import { useListInstruments } from "utils/hooks/domain/instruments/use-list-instruments";
 import { List } from "immutable";
-import { TrackTime } from "components/tracks/track-time/track-time";
 import { SidebarNavigationWidth } from "components/sidebar/sidebar-navigation";
 import { WorkstationTabsHeight } from "components/workstation/workstation-tabs";
 import { calcFrom100 } from "utils/theme-utils";
@@ -59,7 +58,7 @@ const WorkstationPage: React.FC<WorkstationPageProps> = (
     props: WorkstationPageProps
 ) => {
     const { user } = useCurrentUser();
-    const { state, setState } = useWorkstationState();
+    const { setState } = useWorkstationState();
     const {
         state: { isPlaying },
     } = useReactronicaState();

--- a/src/components/pages/workstation-page.tsx
+++ b/src/components/pages/workstation-page.tsx
@@ -1,4 +1,7 @@
-import { SongControls } from "components/workstation/song-controls";
+import {
+    SongControls,
+    SongControlsHeight,
+} from "components/workstation/song-controls";
 import { PlayingTrackList } from "components/tracks/track-list/playing-track-list";
 import {
     AddIcon,
@@ -31,6 +34,9 @@ import { SongComposition } from "components/song-composition/song-composition";
 import { useListInstruments } from "utils/hooks/domain/instruments/use-list-instruments";
 import { List } from "immutable";
 import { TrackTime } from "components/tracks/track-time/track-time";
+import { SidebarNavigationWidth } from "components/sidebar/sidebar-navigation";
+import { WorkstationTabsHeight } from "components/workstation/workstation-tabs";
+import { calcFrom100 } from "utils/theme-utils";
 
 interface WorkstationPageProps extends RouteProps {}
 
@@ -46,6 +52,8 @@ const options: Array<SelectMenuItem<boolean>> = [
         value: true,
     },
 ];
+
+const margin = majorScale(2);
 
 const WorkstationPage: React.FC<WorkstationPageProps> = (
     props: WorkstationPageProps
@@ -164,22 +172,19 @@ const WorkstationPage: React.FC<WorkstationPageProps> = (
     const renderSpinner =
         isLoadingFiles || isLoadingWorkstations || isLoadingInstruments;
     const renderControls = !renderSpinner;
+
     return (
-        <Pane
-            // marginLeft={majorScale(2)}
-            // marginTop={majorScale(2)}
-            height="100%"
-            width="100%">
+        <Pane height="100%" marginTop={margin} width="100%">
             {renderSpinner && <Spinner />}
             {renderControls && (
-                <React.Fragment>
+                <Pane height="100%" marginLeft={margin} width="100%">
                     <SongControls />
                     <Pane
-                        // height="100%"
-                        // width="100%"
-                        height={`calc(100% - 96px)`}
-                        width={`calc(100% - 32px)`}
-                        overflow="auto">
+                        height={calcFrom100(
+                            WorkstationTabsHeight + SongControlsHeight + margin
+                        )}
+                        overflow="auto"
+                        width={calcFrom100(SidebarNavigationWidth + margin)}>
                         <TrackTime stepCount={state.getStepCount()} />
                         {isPlaying && <PlayingTrackList tracks={tracks} />}
                         {!isPlaying && (
@@ -219,7 +224,7 @@ const WorkstationPage: React.FC<WorkstationPageProps> = (
                             </React.Fragment>
                         )}
                     </Pane>
-                </React.Fragment>
+                </Pane>
             )}
             <SongComposition files={files} instruments={instruments} />
         </Pane>

--- a/src/components/pages/workstation-page.tsx
+++ b/src/components/pages/workstation-page.tsx
@@ -195,7 +195,6 @@ const WorkstationPage: React.FC<WorkstationPageProps> = (
                         )}
                         overflow="auto"
                         width={calcFrom100(SidebarNavigationWidth + margin)}>
-                        <TrackTime stepCount={state.getStepCount()} />
                         {isPlaying && <PlayingTrackList tracks={tracks} />}
                         {!isPlaying && (
                             <React.Fragment>

--- a/src/components/pages/workstation-page.tsx
+++ b/src/components/pages/workstation-page.tsx
@@ -166,51 +166,59 @@ const WorkstationPage: React.FC<WorkstationPageProps> = (
     const renderControls = !renderSpinner;
     return (
         <Pane
-            marginLeft={majorScale(2)}
-            marginTop={majorScale(2)}
-            maxWidth={`calc(100% - ${majorScale(4)}px)`}>
+            // marginLeft={majorScale(2)}
+            // marginTop={majorScale(2)}
+            height="100%"
+            width="100%">
             {renderSpinner && <Spinner />}
             {renderControls && (
                 <React.Fragment>
                     <SongControls />
-                    <TrackTime stepCount={state.getStepCount()} />
-                    {isPlaying && <PlayingTrackList tracks={tracks} />}
-                    {!isPlaying && (
-                        <React.Fragment>
-                            <DraggableTrackList tracks={tracks} />
-                            <Pane
-                                display="flex"
-                                flexDirection="row"
-                                marginRight="auto">
-                                <SelectMenu
-                                    calculateHeight={true}
-                                    closeOnSelect={true}
-                                    hasFilter={false}
-                                    isMultiSelect={false}
-                                    onSelect={handleSelect}
-                                    options={options}
-                                    title="Track Type"
-                                    width={majorScale(16)}>
-                                    <Tooltip content="Add Track">
-                                        <IconButton
-                                            icon={AddIcon}
-                                            marginTop={majorScale(2)}
-                                        />
-                                    </Tooltip>
-                                </SelectMenu>
-                            </Pane>
-                            {instrumentDialogOpen && (
-                                <ChooseOrCreateInstrumentDialog
-                                    isShown={true}
-                                    onCloseComplete={
-                                        handleCloseInstrumentDialog
-                                    }
-                                    onSubmit={handleInstrumentSubmit}
-                                    showTabs={globalState.isAuthenticated()}
-                                />
-                            )}
-                        </React.Fragment>
-                    )}
+                    <Pane
+                        // height="100%"
+                        // width="100%"
+                        height={`calc(100% - 96px)`}
+                        width={`calc(100% - 32px)`}
+                        overflow="auto">
+                        <TrackTime stepCount={state.getStepCount()} />
+                        {isPlaying && <PlayingTrackList tracks={tracks} />}
+                        {!isPlaying && (
+                            <React.Fragment>
+                                <DraggableTrackList tracks={tracks} />
+                                <Pane
+                                    display="flex"
+                                    flexDirection="row"
+                                    marginRight="auto">
+                                    <SelectMenu
+                                        calculateHeight={true}
+                                        closeOnSelect={true}
+                                        hasFilter={false}
+                                        isMultiSelect={false}
+                                        onSelect={handleSelect}
+                                        options={options}
+                                        title="Track Type"
+                                        width={majorScale(16)}>
+                                        <Tooltip content="Add Track">
+                                            <IconButton
+                                                icon={AddIcon}
+                                                marginTop={majorScale(2)}
+                                            />
+                                        </Tooltip>
+                                    </SelectMenu>
+                                </Pane>
+                                {instrumentDialogOpen && (
+                                    <ChooseOrCreateInstrumentDialog
+                                        isShown={true}
+                                        onCloseComplete={
+                                            handleCloseInstrumentDialog
+                                        }
+                                        onSubmit={handleInstrumentSubmit}
+                                        showTabs={globalState.isAuthenticated()}
+                                    />
+                                )}
+                            </React.Fragment>
+                        )}
+                    </Pane>
                 </React.Fragment>
             )}
             <SongComposition files={files} instruments={instruments} />

--- a/src/components/sidebar/sidebar-navigation.tsx
+++ b/src/components/sidebar/sidebar-navigation.tsx
@@ -1,4 +1,4 @@
-import { Pane } from "evergreen-ui";
+import { majorScale, Pane } from "evergreen-ui";
 import { useTheme } from "utils/hooks/use-theme";
 import { SidebarLink } from "components/sidebar/sidebar-link";
 import { ProfileMenuCard } from "components/sidebar/profile-menu-card";
@@ -6,6 +6,8 @@ import { Routes } from "routes";
 import { flattenRoutes } from "utils/route-utils";
 
 interface SidebarNavigationProps {}
+
+const SidebarNavigationWidth = majorScale(6);
 
 const SidebarNavigation: React.FC<SidebarNavigationProps> = (
     props: SidebarNavigationProps
@@ -17,7 +19,8 @@ const SidebarNavigation: React.FC<SidebarNavigationProps> = (
             background={theme.colors.gray100}
             display="flex"
             flexDirection="column"
-            height="100%">
+            height="100%"
+            width={SidebarNavigationWidth}>
             <Pane display="flex" flexDirection="column">
                 <SidebarLink route={Routes.root.routes.workstation} />
                 <SidebarLink
@@ -38,4 +41,4 @@ const SidebarNavigation: React.FC<SidebarNavigationProps> = (
     );
 };
 
-export { SidebarNavigation };
+export { SidebarNavigation, SidebarNavigationWidth };

--- a/src/components/sidebar/sidebar-navigation.tsx
+++ b/src/components/sidebar/sidebar-navigation.tsx
@@ -17,14 +17,16 @@ const SidebarNavigation: React.FC<SidebarNavigationProps> = (
             background={theme.colors.gray100}
             display="flex"
             flexDirection="column"
-            height="100vh">
-            <SidebarLink route={Routes.root.routes.workstation} />
-            <SidebarLink
-                matchingRoutes={flattenRoutes(
-                    Routes.root.routes.library.routes
-                )}
-                route={Routes.root.routes.library}
-            />
+            height="100%">
+            <Pane display="flex" flexDirection="column">
+                <SidebarLink route={Routes.root.routes.workstation} />
+                <SidebarLink
+                    matchingRoutes={flattenRoutes(
+                        Routes.root.routes.library.routes
+                    )}
+                    route={Routes.root.routes.library}
+                />
+            </Pane>
             <Pane
                 display="flex"
                 flexDirection="column"

--- a/src/components/tracks/track-card/track-card.tsx
+++ b/src/components/tracks/track-card/track-card.tsx
@@ -28,6 +28,8 @@ import { TrackSectionList } from "components/tracks/track-section-list/track-sec
 import { useDraggable } from "utils/hooks/use-draggable";
 import { ContextualIconButton } from "components/contextual-icon-button";
 import { css, select } from "glamor";
+import { TrackTime } from "components/tracks/track-time/track-time";
+import { useWorkstationState } from "utils/hooks/use-workstation-state";
 
 interface TrackCardProps {
     track: TrackRecord;
@@ -39,6 +41,7 @@ const width = majorScale(21);
 const TrackCard: React.FC<TrackCardProps> = (props: TrackCardProps) => {
     const { track } = props;
     const { id, name, mute, solo, instrument_id, index } = track;
+    const { state: workstationState } = useWorkstationState();
     const { update, remove, state: tracks } = useTracksState();
     const {
         add: addTrackSection,
@@ -95,6 +98,13 @@ const TrackCard: React.FC<TrackCardProps> = (props: TrackCardProps) => {
                 index === tracks.count() - 1 ? -majorScale(1) : undefined
             }
             marginTop={index === 0 ? -majorScale(1) : undefined}>
+            {index === 0 && (
+                <Pane
+                    marginLeft={width + majorScale(3)}
+                    marginTop={majorScale(2)}>
+                    <TrackTime stepCount={workstationState.getStepCount()} />
+                </Pane>
+            )}
             <Draggable draggableId={track.id} index={track.index}>
                 {(provided) => (
                     <Pane
@@ -111,6 +121,7 @@ const TrackCard: React.FC<TrackCardProps> = (props: TrackCardProps) => {
                             display="flex"
                             flexDirection="column"
                             marginRight={majorScale(2)}
+                            minWidth={width}
                             padding={majorScale(1)}
                             width={width}>
                             <Pane

--- a/src/components/tracks/track-time/track-time-card.tsx
+++ b/src/components/tracks/track-time/track-time-card.tsx
@@ -22,6 +22,7 @@ const TrackTimeCard: React.FC<TrackTimeCardProps> = (
 
     const className = css(hover({ transform: "translateY(-2px)" })).toString();
 
+    const step = index + 1 >= 100 ? getLastTwoDigits(index) : index + 1;
     return (
         <Pane
             alignItems="center"
@@ -32,14 +33,22 @@ const TrackTimeCard: React.FC<TrackTimeCardProps> = (
             flexDirection="row"
             height={majorScale(2)}
             justifyContent="center"
+            maxWidth={majorScale(2)}
+            minWidth={majorScale(2)}
             onClick={handleClick}
             transform={state.index === index ? "translateY(-2px)" : undefined}
             width={majorScale(2)}>
             <Text cursor="pointer" fontSize="x-small" userSelect="none">
-                {index + 1}
+                {step}
             </Text>
         </Pane>
     );
+};
+
+const getLastTwoDigits = (index: number): string => {
+    const string = (index + 1).toString();
+    const values = string.split("");
+    return [values.pop()!, values.pop()!].reverse().join("");
 };
 
 export { TrackTimeCard };

--- a/src/components/tracks/track-time/track-time.tsx
+++ b/src/components/tracks/track-time/track-time.tsx
@@ -1,5 +1,5 @@
 import { TrackTimeCard } from "components/tracks/track-time/track-time-card";
-import { majorScale, Pane } from "evergreen-ui";
+import { Pane } from "evergreen-ui";
 import { range } from "lodash";
 
 interface TrackTimeProps {
@@ -9,12 +9,7 @@ interface TrackTimeProps {
 const TrackTime: React.FC<TrackTimeProps> = (props: TrackTimeProps) => {
     const { stepCount } = props;
     return (
-        <Pane
-            display="flex"
-            flexDirection="row"
-            marginLeft={majorScale(24)}
-            marginTop={-16}
-            position="absolute">
+        <Pane display="flex" flexDirection="row">
             {range(0, stepCount).map((index: number) => (
                 <TrackTimeCard index={index} key={index} />
             ))}

--- a/src/components/workstation/song-controls.tsx
+++ b/src/components/workstation/song-controls.tsx
@@ -11,7 +11,7 @@ import {
     CaretUpIcon,
     Heading,
 } from "evergreen-ui";
-import { ChangeEvent, useCallback } from "react";
+import React, { ChangeEvent, useCallback } from "react";
 import { useProjectState } from "utils/hooks/use-project-state";
 import { isNilOrEmpty } from "utils/core-utils";
 import { PlayButton } from "components/workstation/play-button";
@@ -20,6 +20,7 @@ import { useReactronicaState } from "utils/hooks/use-reactronica-state";
 interface SongControlsProps {}
 
 const marginRight = minorScale(2);
+const SongControlsHeight = majorScale(9);
 
 const SongControls: React.FC<SongControlsProps> = (
     props: SongControlsProps
@@ -87,7 +88,7 @@ const SongControls: React.FC<SongControlsProps> = (
     );
 
     return (
-        <Pane>
+        <Pane height={SongControlsHeight}>
             <Heading marginBottom={majorScale(1)} size={500}>
                 {project.name}
             </Heading>
@@ -158,4 +159,4 @@ const SongControls: React.FC<SongControlsProps> = (
     );
 };
 
-export { SongControls };
+export { SongControls, SongControlsHeight };

--- a/src/components/workstation/workstation-tabs.tsx
+++ b/src/components/workstation/workstation-tabs.tsx
@@ -1,18 +1,21 @@
 import { EditTab } from "components/workstation/edit-tab";
 import { FileTab } from "components/workstation/file-tab";
+import { majorScale, Pane } from "evergreen-ui";
 import React from "react";
 
 interface WorkstationTabsProps {}
+
+const WorkstationTabsHeight = majorScale(4);
 
 const WorkstationTabs: React.FC<WorkstationTabsProps> = (
     props: WorkstationTabsProps
 ) => {
     return (
-        <React.Fragment>
+        <Pane height={WorkstationTabsHeight}>
             <FileTab />
             <EditTab />
-        </React.Fragment>
+        </Pane>
     );
 };
 
-export { WorkstationTabs };
+export { WorkstationTabs, WorkstationTabsHeight };

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,15 @@
-body {
+body,
+html {
     margin: 0;
+    height: 100%;
+    width: 100%;
+    padding: 0;
+    overflow: hidden;
+}
+
+#root {
+    height: 100%;
+    max-height: 100%;
+    width: 100%;
+    max-width: 100%;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import App from "app";
+import { App } from "app";
 import reportWebVitals from "reportWebVitals";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ThemeProvider } from "evergreen-ui";

--- a/src/utils/theme-utils.ts
+++ b/src/utils/theme-utils.ts
@@ -12,6 +12,8 @@ const stepColors: Array<DefaultThemeColors> = [
     "red300",
 ];
 
+const calcFrom100 = (value: number) => `calc(100% - ${value}px)`;
+
 const getStepColor = (fileId: string | undefined): string => {
     if (isNilOrEmpty(fileId)) {
         return "transparent";
@@ -22,4 +24,4 @@ const getStepColor = (fileId: string | undefined): string => {
     return theme.colors[key];
 };
 
-export { getStepColor };
+export { calcFrom100, getStepColor };


### PR DESCRIPTION
Resolves #83

- Simplifies DOM with unnecessary `<div>`/`<Pane>` wrappers
- Updates inner content of `WorkstationPage` to be scrollable while `<SidebarNavigation>`, `WorkstationTabs>` and `<SongControls>` remain static.
- `<TrackTime>` component is no longer absolutely positioned and will scroll with the inner content