### PR TITLE
Update to Tone v14 fork of reactronica

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "beets",
             "version": "1.6.0",
             "dependencies": {
-                "@brandongregoryscott/reactronica": "0.9.0",
+                "@brandongregoryscott/reactronica": "0.9.1",
                 "@octokit/rest": "18.12.0",
                 "@supabase/supabase-js": "1.24.0",
                 "evergreen-ui": "6.7.1",
@@ -1892,9 +1892,9 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
         },
         "node_modules/@brandongregoryscott/reactronica": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@brandongregoryscott/reactronica/-/reactronica-0.9.0.tgz",
-            "integrity": "sha512-dlThuwBTgySNFA5Hgwz3FKfJcSHESCmLeLN4kpGp752sSnKoTOnziSU6uG+BVfRZ9OYD48+/LXHvuPmsLFKLWQ==",
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/@brandongregoryscott/reactronica/-/reactronica-0.9.1.tgz",
+            "integrity": "sha512-omSrX96Un5vLTBRVXJnfKhAjyVMPVMu30rAdLBiCX2ngPUhI34eDTYVEtw6+G1w7YmQi4NcIXr7yzMb+uUF6NA==",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "startaudiocontext": "^1.2.1",
@@ -24012,9 +24012,9 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
         },
         "@brandongregoryscott/reactronica": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@brandongregoryscott/reactronica/-/reactronica-0.9.0.tgz",
-            "integrity": "sha512-dlThuwBTgySNFA5Hgwz3FKfJcSHESCmLeLN4kpGp752sSnKoTOnziSU6uG+BVfRZ9OYD48+/LXHvuPmsLFKLWQ==",
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/@brandongregoryscott/reactronica/-/reactronica-0.9.1.tgz",
+            "integrity": "sha512-omSrX96Un5vLTBRVXJnfKhAjyVMPVMu30rAdLBiCX2ngPUhI34eDTYVEtw6+G1w7YmQi4NcIXr7yzMb+uUF6NA==",
             "requires": {
                 "fast-deep-equal": "^3.1.3",
                 "startaudiocontext": "^1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "beets",
             "version": "1.6.0",
             "dependencies": {
-                "@brandongregoryscott/reactronica": "0.8.1",
+                "@brandongregoryscott/reactronica": "0.9.0",
                 "@octokit/rest": "18.12.0",
                 "@supabase/supabase-js": "1.24.0",
                 "evergreen-ui": "6.7.1",
@@ -1892,13 +1892,13 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
         },
         "node_modules/@brandongregoryscott/reactronica": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@brandongregoryscott/reactronica/-/reactronica-0.8.1.tgz",
-            "integrity": "sha512-n2rhgG20soIqD2HzvfC8ydDQf7B2jb0LmtINExcHMMB+SQd/3Aig12GDwzYSvn2MnaWqf1ONRfZQ3GcSd1b+Lg==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@brandongregoryscott/reactronica/-/reactronica-0.9.0.tgz",
+            "integrity": "sha512-dlThuwBTgySNFA5Hgwz3FKfJcSHESCmLeLN4kpGp752sSnKoTOnziSU6uG+BVfRZ9OYD48+/LXHvuPmsLFKLWQ==",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "startaudiocontext": "^1.2.1",
-                "tone": "^13.8.34"
+                "tone": "^14.7.77"
             },
             "engines": {
                 "node": ">=10"
@@ -1906,11 +1906,6 @@
             "peerDependencies": {
                 "react": ">=16"
             }
-        },
-        "node_modules/@brandongregoryscott/reactronica/node_modules/tone": {
-            "version": "13.8.34",
-            "resolved": "https://registry.npmjs.org/tone/-/tone-13.8.34.tgz",
-            "integrity": "sha512-sFIYee0CO5lDcnC/RwIPiPMOIZCMEk35AaxF0Q64q7SE1BL+i+efYR6vrD+peDGrswXJ+D3bTmci2wCy+omx+Q=="
         },
         "node_modules/@cnakazawa/watch": {
             "version": "1.0.4",
@@ -24017,20 +24012,13 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
         },
         "@brandongregoryscott/reactronica": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@brandongregoryscott/reactronica/-/reactronica-0.8.1.tgz",
-            "integrity": "sha512-n2rhgG20soIqD2HzvfC8ydDQf7B2jb0LmtINExcHMMB+SQd/3Aig12GDwzYSvn2MnaWqf1ONRfZQ3GcSd1b+Lg==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@brandongregoryscott/reactronica/-/reactronica-0.9.0.tgz",
+            "integrity": "sha512-dlThuwBTgySNFA5Hgwz3FKfJcSHESCmLeLN4kpGp752sSnKoTOnziSU6uG+BVfRZ9OYD48+/LXHvuPmsLFKLWQ==",
             "requires": {
                 "fast-deep-equal": "^3.1.3",
                 "startaudiocontext": "^1.2.1",
-                "tone": "^13.8.34"
-            },
-            "dependencies": {
-                "tone": {
-                    "version": "13.8.34",
-                    "resolved": "https://registry.npmjs.org/tone/-/tone-13.8.34.tgz",
-                    "integrity": "sha512-sFIYee0CO5lDcnC/RwIPiPMOIZCMEk35AaxF0Q64q7SE1BL+i+efYR6vrD+peDGrswXJ+D3bTmci2wCy+omx+Q=="
-                }
+                "tone": "^14.7.77"
             }
         },
         "@cnakazawa/watch": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         ]
     },
     "dependencies": {
-        "@brandongregoryscott/reactronica": "0.9.0",
+        "@brandongregoryscott/reactronica": "0.9.1",
         "@octokit/rest": "18.12.0",
         "@supabase/supabase-js": "1.24.0",
         "evergreen-ui": "6.7.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         ]
     },
     "dependencies": {
-        "@brandongregoryscott/reactronica": "0.8.1",
+        "@brandongregoryscott/reactronica": "0.9.0",
         "@octokit/rest": "18.12.0",
         "@supabase/supabase-js": "1.24.0",
         "evergreen-ui": "6.7.1",

--- a/src/components/song-composition/song-composition.tsx
+++ b/src/components/song-composition/song-composition.tsx
@@ -6,6 +6,7 @@ import { InstrumentRecord } from "models/instrument-record";
 import { useProjectState } from "utils/hooks/use-project-state";
 import { useReactronicaState } from "utils/hooks/use-reactronica-state";
 import { useTracksState } from "utils/hooks/use-tracks-state";
+import { useWorkstationState } from "utils/hooks/use-workstation-state";
 
 interface SongCompositionProps {
     files: List<FileRecord>;
@@ -18,6 +19,7 @@ const SongComposition: React.FC<SongCompositionProps> = (
     const { files, instruments } = props;
     const { state: reactronicaState } = useReactronicaState();
     const { isMuted, isPlaying } = reactronicaState;
+    const { state: workstationState } = useWorkstationState();
     const { state: project } = useProjectState();
     const { state: tracks } = useTracksState();
     const { bpm, swing, volume } = project;
@@ -27,6 +29,7 @@ const SongComposition: React.FC<SongCompositionProps> = (
             bpm={bpm}
             isMuted={isMuted}
             isPlaying={isPlaying}
+            key={workstationState.getKey()}
             swing={swing / 100}
             volume={volume}>
             {tracks.map((track) => (

--- a/src/interfaces/reactronica-state.ts
+++ b/src/interfaces/reactronica-state.ts
@@ -1,4 +1,4 @@
-import { StepNoteType } from "lib/reactronica";
+import { StepType } from "lib/reactronica";
 
 interface ReactronicaState {
     /** Step index to stop playing the track at */
@@ -8,7 +8,7 @@ interface ReactronicaState {
     isMuted: boolean;
     isPlaying: boolean;
     /** Current notes being played */
-    notes: StepNoteType[];
+    notes: StepType;
     /** Step index to start playing the track at */
     startIndex?: number;
 }

--- a/src/models/workstation-state-record.ts
+++ b/src/models/workstation-state-record.ts
@@ -254,6 +254,10 @@ class WorkstationStateRecord
         return stepSums.max()!;
     }
 
+    public getKey(): string {
+        return JSON.stringify(this.toJS());
+    }
+
     public isDemo(): boolean {
         return this.project.isDemo();
     }

--- a/src/utils/hooks/use-reactronica-state.ts
+++ b/src/utils/hooks/use-reactronica-state.ts
@@ -1,7 +1,7 @@
 import { ReactronicaState } from "interfaces/reactronica-state";
 import { SetStateAction, useAtom } from "jotai";
 import { useCallback, useMemo, useState } from "react";
-import { StepNoteType } from "lib/reactronica";
+import { StepType } from "lib/reactronica";
 import {
     initialReactronicaState,
     ReactronicaStateAtom,
@@ -20,7 +20,7 @@ interface UseReactronicaStateResult {
     isSelected: (index: number) => boolean;
     onIndexClick: (index: number) => void;
     onPlayToggle: (isPlaying: boolean) => void;
-    onStepPlay: (notes: StepNoteType[], index: number) => void;
+    onStepPlay: (notes: StepType, index: number) => void;
     setIsMuted: (update: SetStateAction<boolean>) => void;
     setIsPlaying: (update: SetStateAction<boolean>) => void;
     setState: (update: SetStateAction<ReactronicaState>) => void;
@@ -76,7 +76,7 @@ const useReactronicaState = (
     );
 
     const onStepPlay = useCallback(
-        (notes: StepNoteType[], index: number) =>
+        (notes: StepType, index: number) =>
             setState((prev) => ({
                 ...prev,
                 notes,


### PR DESCRIPTION
Upgrades the fork of `reactronica` which uses Tone v14 under the hood. I encountered a weird issue where changing the steps would cause the song to be silent after playing, but adding a `key` prop to the top-level `Song` based on the workstation data solved this issue. It seems like a bit of a hack, but it'll work for now. 

This should unblock #37 