### PR TITLE
Use currentIndex in PianoRoll, Sequencer, fix off-by-1 UI<>Audio sync

### DIFF
--- a/src/components/piano-roll/piano-roll.tsx
+++ b/src/components/piano-roll/piano-roll.tsx
@@ -18,10 +18,9 @@ import { MidiNotes } from "constants/midi-notes";
 import { InstrumentRecord } from "models/instrument-record";
 import { MidiNoteUtils } from "utils/midi-note-utils";
 import { MidiNote } from "types/midi-note";
-import { useAtomValue } from "jotai/utils";
 import { useToneAudio } from "utils/hooks/use-tone-audio";
-import { CurrentIndexAtom } from "utils/atoms/current-index-atom";
 import { TrackRecord } from "models/track-record";
+import { useCurrentIndex } from "utils/hooks/use-current-index";
 
 interface PianoRollProps {
     file?: FileRecord;
@@ -55,7 +54,7 @@ const PianoRoll: React.FC<PianoRollProps> = (props: PianoRollProps) => {
             : defaultNoteIndex
     );
     const { value: isPlaying, toggle: toggleIsPlaying } = useBoolean();
-    const currentIndex = useAtomValue(CurrentIndexAtom);
+    const currentIndex = useCurrentIndex({ endIndex: stepCount - 1 });
     const { isLoading } = useToneAudio({
         isPlaying,
         instruments: instrument != null ? List.of(instrument) : undefined,

--- a/src/components/sequencer/sequencer.tsx
+++ b/src/components/sequencer/sequencer.tsx
@@ -13,8 +13,7 @@ import { useBoolean } from "utils/hooks/use-boolean";
 import { PlayButton } from "components/workstation/play-button";
 import { useToneAudio } from "utils/hooks/use-tone-audio";
 import { TrackRecord } from "models/track-record";
-import { useAtomValue } from "jotai/utils";
-import { CurrentIndexAtom } from "utils/atoms/current-index-atom";
+import { useCurrentIndex } from "utils/hooks/use-current-index";
 
 interface SequencerProps {
     files: List<FileRecord>;
@@ -58,7 +57,9 @@ const Sequencer: React.FC<SequencerProps> = (props: SequencerProps) => {
         [setSelected]
     );
 
-    const currentIndex = useAtomValue(CurrentIndexAtom);
+    const currentIndex = useCurrentIndex({
+        endIndex: stepCount - 1,
+    });
     const { isLoading } = useToneAudio({
         isPlaying,
         files,

--- a/src/components/tracks/track-section-card/track-section-step-column.tsx
+++ b/src/components/tracks/track-section-card/track-section-step-column.tsx
@@ -4,9 +4,8 @@ import { List } from "immutable";
 import { useAtomValue } from "jotai/utils";
 import { range } from "lodash";
 import { TrackSectionStepRecord } from "models/track-section-step-record";
-import { CurrentIndexAtom } from "utils/atoms/current-index-atom";
 import { ToneStateAtom } from "utils/atoms/tone-state-atom";
-import { clampIndexToRange } from "utils/track-section-step-utils";
+import { useCurrentIndex } from "utils/hooks/use-current-index";
 
 interface TrackSectionStepColumnProps {
     index: number;
@@ -22,15 +21,12 @@ const TrackSectionStepColumn: React.FC<TrackSectionStepColumnProps> = (
 ) => {
     const { index, stepCount, stepCountOffset, trackSectionSteps } = props;
     const { isPlaying, startIndex, endIndex } = useAtomValue(ToneStateAtom);
-    const currentIndex = useAtomValue(CurrentIndexAtom);
-
-    const playingIndex = clampIndexToRange({
-        index: currentIndex,
+    const currentIndex = useCurrentIndex({
         startIndex,
         endIndex: endIndex ?? stepCount - 1,
     });
     const activeProps =
-        isPlaying && index + stepCountOffset === playingIndex
+        isPlaying && index + stepCountOffset === currentIndex
             ? {
                   elevation: 4 as Elevation,
                   transform: "translateY(-2px)",

--- a/src/utils/atoms/current-index-atom.ts
+++ b/src/utils/atoms/current-index-atom.ts
@@ -1,5 +1,9 @@
-import { atom } from "jotai";
+import { atomWithReset } from "jotai/utils";
 
-const CurrentIndexAtom = atom<number>(0);
+/**
+ * Tracks the current index of the playing step. Starts at -1 to be in sync with the first step that
+ * increments to 0.
+ */
+const CurrentIndexAtom = atomWithReset<number>(-1);
 
 export { CurrentIndexAtom };

--- a/src/utils/hooks/use-current-index.ts
+++ b/src/utils/hooks/use-current-index.ts
@@ -1,0 +1,22 @@
+import { useAtomValue } from "jotai/utils";
+import { CurrentIndexAtom } from "utils/atoms/current-index-atom";
+import {
+    clampIndexToRange,
+    ClampIndexToRangeOptions,
+} from "utils/track-section-step-utils";
+
+interface UseCurrentIndexOptions
+    extends Pick<ClampIndexToRangeOptions, "startIndex" | "endIndex"> {}
+
+const useCurrentIndex = (options: UseCurrentIndexOptions) => {
+    const { startIndex, endIndex } = options;
+    const index = useAtomValue(CurrentIndexAtom);
+
+    return clampIndexToRange({
+        index,
+        startIndex,
+        endIndex,
+    });
+};
+
+export { useCurrentIndex };

--- a/src/utils/hooks/use-tone-playing-effect.ts
+++ b/src/utils/hooks/use-tone-playing-effect.ts
@@ -1,10 +1,10 @@
-import { useUpdateAtom } from "jotai/utils";
+import { useResetAtom } from "jotai/utils";
 import { useEffect } from "react";
 import * as Tone from "tone";
 import { CurrentIndexAtom } from "utils/atoms/current-index-atom";
 
 const useTonePlayingEffect = (isPlaying?: boolean): void => {
-    const setCurrentIndex = useUpdateAtom(CurrentIndexAtom);
+    const resetCurrentIndex = useResetAtom(CurrentIndexAtom);
 
     useEffect(() => {
         if (isPlaying) {
@@ -13,8 +13,8 @@ const useTonePlayingEffect = (isPlaying?: boolean): void => {
         }
 
         Tone.Transport.stop();
-        setCurrentIndex(0);
-    }, [isPlaying, setCurrentIndex]);
+        resetCurrentIndex();
+    }, [isPlaying, resetCurrentIndex]);
 };
 
 export { useTonePlayingEffect };

--- a/src/utils/track-section-step-utils.ts
+++ b/src/utils/track-section-step-utils.ts
@@ -137,3 +137,5 @@ export {
     toInstrumentStepTypes,
     toSequencerStepTypes,
 };
+
+export type { ClampIndexToRangeOptions };


### PR DESCRIPTION
Fixes these issues:
- Current playing step in the `PianoRoll`/`Sequencer` preview wasn't looping correctly
- UI and audio were out of sync by 1 step (UI being faster than the audio)
- Use `atomWithReset` and `useResetAtom` utils to reduce duplicated 'initial value'
- Break out `useCurrentIndex` hook that automatically clamps to range to reduce duplicated code