### PR TITLE
Feature: Export as file

### DIFF
--- a/src/components/workstation/export-dialog.tsx
+++ b/src/components/workstation/export-dialog.tsx
@@ -1,0 +1,126 @@
+import { Dialog, DialogProps } from "components/dialog";
+import {
+    Button,
+    ExportIcon,
+    majorScale,
+    Paragraph,
+    RecordIcon,
+    Spinner,
+} from "evergreen-ui";
+import { List } from "immutable";
+import React, { useCallback, useState } from "react";
+import { useListFiles } from "utils/hooks/domain/files/use-list-files";
+import { useListInstruments } from "utils/hooks/domain/instruments/use-list-instruments";
+import { useBoolean } from "utils/hooks/use-boolean";
+import { useToneAudio } from "utils/hooks/use-tone-audio";
+import { useWorkstationState } from "utils/hooks/use-workstation-state";
+import * as Tone from "tone";
+import { formatNow } from "utils/date-utils";
+import { ProjectRecord } from "models/project-record";
+import { useTheme } from "utils/hooks/use-theme";
+
+interface ExportDialogProps
+    extends Pick<DialogProps, "isShown" | "onCloseComplete"> {}
+
+const title = "Export as Audio";
+
+const ExportDialog: React.FC<ExportDialogProps> = (
+    props: ExportDialogProps
+) => {
+    const { isShown, onCloseComplete } = props;
+    const { colors } = useTheme();
+    const { resultObject: files = List(), isLoading: isLoadingFiles } =
+        useListFiles();
+    const {
+        resultObject: instruments = List(),
+        isLoading: isLoadingInstruments,
+    } = useListInstruments({ files });
+    const { state } = useWorkstationState();
+    const {
+        value: isRecording,
+        setTrue: startRecording,
+        setFalse: stopRecording,
+    } = useBoolean();
+    const [blob, setBlob] = useState<Blob>();
+    const handleRecordingComplete = useCallback(
+        (file: Blob) => {
+            setBlob(file);
+            stopRecording();
+        },
+        [stopRecording]
+    );
+
+    const { isLoading: isLoadingSamples } = useToneAudio({
+        lengthInMs: state.getLengthInMs(),
+        onRecordingComplete: handleRecordingComplete,
+        isRecording,
+        files,
+        instruments,
+        tracks: state.tracks,
+        trackSections: state.trackSections,
+        trackSectionSteps: state.trackSectionSteps,
+    });
+
+    const isLoading =
+        isLoadingFiles || isLoadingInstruments || isLoadingSamples;
+
+    const handleExportClick = useCallback(async () => {
+        // Ensure AudioContext is started
+        await Tone.start();
+        startRecording();
+    }, [startRecording]);
+
+    const handleClose = useCallback(() => {
+        stopRecording();
+        onCloseComplete?.();
+    }, [onCloseComplete, stopRecording]);
+    return (
+        <Dialog
+            confirmLabel="Close"
+            hasCancel={false}
+            isShown={isShown}
+            onCloseComplete={handleClose}
+            shouldCloseOnOverlayClick={false}
+            title={title}>
+            {isLoading && <Spinner />}
+            {!isLoading && (
+                <React.Fragment>
+                    <Paragraph marginBottom={majorScale(2)}>
+                        To export the project as an audio file, click the button
+                        below. Recording happens in real-time, and you'll be
+                        able to download the file once complete.
+                    </Paragraph>
+                    <Button
+                        allowUnsafeHref={true}
+                        appearance={blob == null ? "default" : "primary"}
+                        download={getFileName(state.project)}
+                        href={
+                            blob != null ? URL.createObjectURL(blob) : undefined
+                        }
+                        iconBefore={
+                            blob == null ? (
+                                <RecordIcon
+                                    color={
+                                        isRecording ? colors.red600 : undefined
+                                    }
+                                />
+                            ) : (
+                                ExportIcon
+                            )
+                        }
+                        is="a"
+                        isLoading={isRecording}
+                        onClick={blob == null ? handleExportClick : undefined}
+                        width="100%">
+                        {blob == null ? "Export" : "Download file"}
+                    </Button>
+                </React.Fragment>
+            )}
+        </Dialog>
+    );
+};
+
+const getFileName = (project: ProjectRecord): string =>
+    `${project.name} ${formatNow()}.webm`;
+
+export { ExportDialog };

--- a/src/components/workstation/export-dialog.tsx
+++ b/src/components/workstation/export-dialog.tsx
@@ -1,7 +1,10 @@
 import { Dialog, DialogProps } from "components/dialog";
 import {
+    Alert,
     Button,
     ExportIcon,
+    Link,
+    Text,
     majorScale,
     Paragraph,
     RecordIcon,
@@ -90,6 +93,19 @@ const ExportDialog: React.FC<ExportDialogProps> = (
                         below. Recording happens in real-time, and you'll be
                         able to download the file once complete.
                     </Paragraph>
+                    <Alert
+                        marginBottom={majorScale(2)}
+                        title="The file will be exported as a .webm file">
+                        <Text>
+                            Use a site like{" "}
+                            <Link
+                                href="https://cloudconvert.com/webm-converter"
+                                target="_blank">
+                                CloudConvert
+                            </Link>{" "}
+                            to convert it to your desired format.
+                        </Text>
+                    </Alert>
                     <Button
                         allowUnsafeHref={true}
                         appearance={blob == null ? "default" : "primary"}
@@ -112,7 +128,11 @@ const ExportDialog: React.FC<ExportDialogProps> = (
                         isLoading={isRecording}
                         onClick={blob == null ? handleExportClick : undefined}
                         width="100%">
-                        {blob == null ? "Export" : "Download file"}
+                        {blob == null && !isRecording && "Export"}
+                        {isRecording && (
+                            <Text color={colors.red600}>Recording...</Text>
+                        )}
+                        {blob != null && !isRecording && "Download file"}
                     </Button>
                 </React.Fragment>
             )}

--- a/src/components/workstation/file-tab.tsx
+++ b/src/components/workstation/file-tab.tsx
@@ -14,6 +14,7 @@ import { useDialog } from "utils/hooks/use-dialog";
 import { ProjectSettingsDialog } from "components/workstation/project-settings-dialog";
 import { isNotNilOrEmpty } from "utils/core-utils";
 import { useHotkeys } from "react-hotkeys-hook";
+import { ExportDialog } from "components/workstation/export-dialog";
 
 interface FileTabProps {}
 
@@ -43,6 +44,11 @@ const FileTab: React.FC<FileTabProps> = (props: FileTabProps) => {
         isConfirmDialogOpen,
         handleOpenConfirmDialog,
         handleCloseConfirmDialog,
+    ] = useDialog();
+    const [
+        isExportDialogOpen,
+        handleOpenExportDialog,
+        handleCloseExportDialog,
     ] = useDialog();
     const [
         isSettingsDialogOpen,
@@ -178,6 +184,14 @@ const FileTab: React.FC<FileTabProps> = (props: FileTabProps) => {
         [handleOpenSettingsDialog]
     );
 
+    const handleExportClick = useCallback(
+        (closePopover: () => void) => () => {
+            handleOpenExportDialog();
+            closePopover();
+        },
+        [handleOpenExportDialog]
+    );
+
     return (
         <React.Fragment>
             <Popover
@@ -193,6 +207,9 @@ const FileTab: React.FC<FileTabProps> = (props: FileTabProps) => {
                             onClick={handleSave(closePopover)}
                             secondaryText={"⌘S" as any}>
                             Save
+                        </Menu.Item>
+                        <Menu.Item onClick={handleExportClick(closePopover)}>
+                            Export
                         </Menu.Item>
                         <Menu.Item onClick={handleSettingsClick(closePopover)}>
                             Settings
@@ -255,6 +272,12 @@ const FileTab: React.FC<FileTabProps> = (props: FileTabProps) => {
                 <ProjectSettingsDialog
                     isShown={isSettingsDialogOpen}
                     onCloseComplete={handleCloseSettingsDialog}
+                />
+            )}
+            {isExportDialogOpen && (
+                <ExportDialog
+                    isShown={isExportDialogOpen}
+                    onCloseComplete={handleCloseExportDialog}
                 />
             )}
         </React.Fragment>

--- a/src/interfaces/tone-state.ts
+++ b/src/interfaces/tone-state.ts
@@ -3,6 +3,7 @@ import { Subdivision } from "tone/build/esm/core/type/Units";
 interface ToneState {
     endIndex?: number;
     isPlaying?: boolean;
+    isRecording?: boolean;
     mute?: boolean;
     startIndex?: number;
     subdivision?: Subdivision;

--- a/src/models/workstation-state-record.ts
+++ b/src/models/workstation-state-record.ts
@@ -241,6 +241,13 @@ class WorkstationStateRecord
         return diff;
     }
 
+    public getLengthInMs(): number {
+        const stepCount = this.getStepCount();
+        const { bpm } = this.project;
+        // Increment the step count to account for tail audio
+        return 1000 * ((60 / bpm) * ((stepCount + 1) / 2));
+    }
+
     public getStepCount(): number {
         // Calculate sum of steps by track
         const stepSums = this.tracks.map((track) => {

--- a/src/utils/atoms/tone-state-atom.ts
+++ b/src/utils/atoms/tone-state-atom.ts
@@ -4,6 +4,7 @@ import { atom } from "jotai";
 const ToneStateAtom = atom<ToneState>({
     endIndex: undefined,
     isPlaying: false,
+    isRecording: false,
     mute: false,
     startIndex: undefined,
     subdivision: "8n",

--- a/src/utils/date-utils.ts
+++ b/src/utils/date-utils.ts
@@ -1,6 +1,8 @@
 import { DateTime } from "luxon";
 import { isNilOrEmpty } from "utils/collection-utils";
 
+const formatNow = (): string => formatUpdatedOn(new Date().toISOString());
+
 const formatUpdatedOn = (updated_on?: string): string =>
     isNilOrEmpty(updated_on)
         ? "--"
@@ -8,4 +10,4 @@ const formatUpdatedOn = (updated_on?: string): string =>
               DateTime.DATETIME_MED_WITH_WEEKDAY
           );
 
-export { formatUpdatedOn };
+export { formatNow, formatUpdatedOn };


### PR DESCRIPTION
Implements a first pass of exporting audio as a file using the `Tone.Recorder` class. Unfortunately, the `MediaRecorder` API is pretty limited and we can't export as a `wav` or `mp3` file natively yet. 