### PR TITLE
Bug: Rebase track indexes, misc. layout/style issues

### DIFF
--- a/src/components/layouts/library-layout.tsx
+++ b/src/components/layouts/library-layout.tsx
@@ -34,7 +34,7 @@ const LibraryLayout: React.FC<LibraryLayoutProps> = (
     );
 
     return (
-        <Pane height="100vh" overflow="auto">
+        <Pane height="100%" overflow="auto" width="100%">
             <Pane marginLeft={majorScale(2)} marginTop={majorScale(2)}>
                 <TabNavigation>
                     {tabs.map((tab) => (

--- a/src/components/pages/register-page.tsx
+++ b/src/components/pages/register-page.tsx
@@ -1,5 +1,5 @@
 import { LoginOrRegister } from "components/login-or-register";
-import { majorScale, Pane } from "evergreen-ui";
+import { Pane } from "evergreen-ui";
 import { RouteProps } from "interfaces/route-props";
 
 interface RegisterPageProps extends RouteProps {}
@@ -12,8 +12,8 @@ const RegisterPage: React.FC<RegisterPageProps> = (
             alignItems="center"
             display="flex"
             flexDirection="column"
-            height={`calc(100% - ${majorScale(12)}px)`}
-            justifyContent="center">
+            justifyContent="center"
+            width="100%">
             <LoginOrRegister initialShowRegister={true} />
         </Pane>
     );

--- a/src/components/tracks/track-list/draggable-track-list.tsx
+++ b/src/components/tracks/track-list/draggable-track-list.tsx
@@ -35,7 +35,6 @@ const DraggableTrackList: React.FC<DraggableTrackListProps> = (
                         borderRadius={minorScale(1)}
                         display="flex"
                         flexDirection="column"
-                        margin={-2}
                         ref={provided.innerRef}
                         {...provided.droppableProps}>
                         <TrackList tracks={tracks} />

--- a/src/utils/hooks/use-draggable.ts
+++ b/src/utils/hooks/use-draggable.ts
@@ -4,7 +4,7 @@ import { SetStateAction, useAtom } from "jotai";
 import { useCallback } from "react";
 import { DragStart, DropResult, ResponderProvided } from "react-beautiful-dnd";
 import { DraggableAtom } from "utils/atoms/draggable-atom";
-import { reorder } from "utils/collection-utils";
+import { rebaseIndexes, reorder } from "utils/collection-utils";
 
 interface UseDraggableOptions<T extends OrderableEntity> {
     setState?: (update: SetStateAction<List<T>>) => void;
@@ -37,7 +37,7 @@ const useDraggable = <T extends OrderableEntity>(
             }
 
             setState?.((prev) =>
-                reorder(prev, source.index, destination.index)
+                rebaseIndexes(reorder(prev, source.index, destination.index))
             );
         },
         [setDraggableId, setState]


### PR DESCRIPTION

- Looks like there was a bug and `Track` indexes weren't properly being set. Unless there's a track with index `0`, the `TrackTime` component doesn't show. Calling `rebaseIndexes` after `reorder` should resolve this to ensure indexes are always consecutive and non-overlapping.
- Fix width in `LibraryLayout` which was clamping the width to the `FileList`
- Properly center `LoginOrRegister` component on `RegisterPage`
- Remove margin from `DraggableTrackList` so that border shows when dragging