### PR TITLE
Fix groupBy function to ensure StorageProviderFiles & Files are matched up correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
                 "collation": "0.7.1",
                 "dotenv": "10.0.0",
                 "husky": "7.0.4",
+                "jest-extended": "1.2.1",
                 "node-pg-migrate": "6.0.0",
                 "openapi-typescript": "4.4.0",
                 "pluralize": "8.0.0",
@@ -4379,9 +4380,9 @@
             }
         },
         "node_modules/ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "engines": {
                 "node": ">=8"
             }
@@ -11978,6 +11979,95 @@
             },
             "engines": {
                 "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-extended": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-1.2.1.tgz",
+            "integrity": "sha512-eKZR5iDpyTkcDesj16FpIPnjAWQNUB81ZFQW08EIddM6iqO7DjRIi39td9qol+1dpJS4Mqr9Qzp8ZMhanbSeug==",
+            "dev": true,
+            "dependencies": {
+                "expect": "^26.6.2",
+                "jest-diff": "^27.2.5",
+                "jest-get-type": "^27.0.6",
+                "jest-matcher-utils": "^27.2.4"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/jest-extended/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/jest-extended/node_modules/diff-sequences": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
+            "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
+            "dev": true,
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/jest-extended/node_modules/jest-diff": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
+            "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "diff-sequences": "^27.5.1",
+                "jest-get-type": "^27.5.1",
+                "pretty-format": "^27.5.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/jest-extended/node_modules/jest-get-type": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
+            "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
+            "dev": true,
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/jest-extended/node_modules/jest-matcher-utils": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz",
+            "integrity": "sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "jest-diff": "^27.5.1",
+                "jest-get-type": "^27.5.1",
+                "pretty-format": "^27.5.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/jest-extended/node_modules/pretty-format": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^17.0.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
         "node_modules/jest-get-type": {
@@ -27275,9 +27365,9 @@
             "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
         },
         "ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
         },
         "ansi-styles": {
             "version": "3.2.1",
@@ -33175,6 +33265,73 @@
                 "@types/node": "*",
                 "jest-mock": "^26.6.2",
                 "jest-util": "^26.6.2"
+            }
+        },
+        "jest-extended": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-1.2.1.tgz",
+            "integrity": "sha512-eKZR5iDpyTkcDesj16FpIPnjAWQNUB81ZFQW08EIddM6iqO7DjRIi39td9qol+1dpJS4Mqr9Qzp8ZMhanbSeug==",
+            "dev": true,
+            "requires": {
+                "expect": "^26.6.2",
+                "jest-diff": "^27.2.5",
+                "jest-get-type": "^27.0.6",
+                "jest-matcher-utils": "^27.2.4"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+                    "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+                    "dev": true
+                },
+                "diff-sequences": {
+                    "version": "27.5.1",
+                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
+                    "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
+                    "dev": true
+                },
+                "jest-diff": {
+                    "version": "27.5.1",
+                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
+                    "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^4.0.0",
+                        "diff-sequences": "^27.5.1",
+                        "jest-get-type": "^27.5.1",
+                        "pretty-format": "^27.5.1"
+                    }
+                },
+                "jest-get-type": {
+                    "version": "27.5.1",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
+                    "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
+                    "dev": true
+                },
+                "jest-matcher-utils": {
+                    "version": "27.5.1",
+                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz",
+                    "integrity": "sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^4.0.0",
+                        "jest-diff": "^27.5.1",
+                        "jest-get-type": "^27.5.1",
+                        "pretty-format": "^27.5.1"
+                    }
+                },
+                "pretty-format": {
+                    "version": "27.5.1",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+                    "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.1",
+                        "ansi-styles": "^5.0.0",
+                        "react-is": "^17.0.1"
+                    }
+                }
             }
         },
         "jest-get-type": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
         "collation": "0.7.1",
         "dotenv": "10.0.0",
         "husky": "7.0.4",
+        "jest-extended": "1.2.1",
         "node-pg-migrate": "6.0.0",
         "openapi-typescript": "4.4.0",
         "pluralize": "8.0.0",

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,7 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom";
+/* @ts-ignore */
+import * as matchers from "jest-extended";
+
+expect.extend(matchers);

--- a/src/utils/collection-utils.test.ts
+++ b/src/utils/collection-utils.test.ts
@@ -1,6 +1,7 @@
 import { List, Range } from "immutable";
 import { random } from "lodash";
 import { TrackRecord } from "models/track-record";
+import { TrackSectionRecord } from "models/track-section-record";
 import { groupBy } from "./collection-utils";
 
 describe("CollectionUtils", () => {
@@ -44,12 +45,30 @@ describe("CollectionUtils", () => {
                 .map(() => new TrackRecord())
                 .toList();
             const left = List(objects);
-            const right = List(objects).sort(() => random());
+            const right = List(
+                objects.map((track) =>
+                    new TrackSectionRecord().merge({ track_id: track.id })
+                )
+            ).sort(() => random(-1, 1, false));
 
-            const result = groupBy(left, right, matchById);
+            const result = groupBy(
+                left,
+                right,
+                (left, right) => left.id === right.track_id
+            );
 
             expect(result).not.toBeEmpty();
-            expect(result.count()).toBe(objects.count());
+            expect(result.count()).toBe(left.count());
+            left.forEach((left) => {
+                expect(
+                    result.find((grouping) => grouping.left === left)
+                ).not.toBeNil();
+            });
+            right.forEach((right) => {
+                expect(
+                    result.find((grouping) => grouping.right === right)
+                ).not.toBeNil();
+            });
         });
     });
 });

--- a/src/utils/collection-utils.test.ts
+++ b/src/utils/collection-utils.test.ts
@@ -1,4 +1,5 @@
-import { List } from "immutable";
+import { List, Range } from "immutable";
+import { random } from "lodash";
 import { TrackRecord } from "models/track-record";
 import { groupBy } from "./collection-utils";
 
@@ -14,6 +15,41 @@ describe("CollectionUtils", () => {
             const result = groupBy(left, right, matchById);
 
             expect(result).toBeEmpty();
+        });
+
+        it("given object exists in right collection but not left, object is not returned", () => {
+            const left = List<TrackRecord>();
+            const right = List.of(new TrackRecord());
+
+            const result = groupBy(left, right, matchById);
+
+            expect(result).toBeEmpty();
+        });
+
+        it("given object exists in both collections, object is returned", () => {
+            const object = new TrackRecord();
+            const left = List.of(object);
+            const right = List.of(object);
+
+            const result = groupBy(left, right, matchById);
+
+            expect(result).not.toBeEmpty();
+            const grouping = result.first()!;
+            expect(grouping.left).toBe(object);
+            expect(grouping.right).toBe(object);
+        });
+
+        it("given object exists in both collections but is in different order, object is returned", () => {
+            const objects = Range(0, 10)
+                .map(() => new TrackRecord())
+                .toList();
+            const left = List(objects);
+            const right = List(objects).sort(() => random());
+
+            const result = groupBy(left, right, matchById);
+
+            expect(result).not.toBeEmpty();
+            expect(result.count()).toBe(objects.count());
         });
     });
 });

--- a/src/utils/collection-utils.test.ts
+++ b/src/utils/collection-utils.test.ts
@@ -1,0 +1,19 @@
+import { List } from "immutable";
+import { TrackRecord } from "models/track-record";
+import { groupBy } from "./collection-utils";
+
+describe("CollectionUtils", () => {
+    describe("groupBy", () => {
+        const matchById = (left: TrackRecord, right: TrackRecord): boolean =>
+            left.id === right.id;
+
+        it("given object exists in left collection but not right, object is not returned", () => {
+            const left = List.of(new TrackRecord());
+            const right = List<TrackRecord>();
+
+            const result = groupBy(left, right, matchById);
+
+            expect(result).toBeEmpty();
+        });
+    });
+});

--- a/src/utils/collection-utils.ts
+++ b/src/utils/collection-utils.ts
@@ -43,24 +43,21 @@ const groupBy = <TLeft, TRight>(
     left = List.isList(left) ? left.toArray() : List(left).toArray();
     right = List.isList(right) ? right.toArray() : List(right).toArray();
 
-    left = _.intersectionWith(left, right, comparator).sort();
-    right = _.intersectionWith(right, left, (right, left) =>
-        comparator(left, right)
-    ).sort();
+    const grouped: Array<Grouping<TLeft, TRight> | undefined> = left.map(
+        (leftValue: TLeft) => {
+            const rightValue = right?.find((rightValue: TRight) =>
+                comparator(leftValue, rightValue)
+            );
 
-    const zipped = _.zipWith(
-        left,
-        right,
-        (left: TLeft, right: TRight): Grouping<TLeft, TRight> | undefined => {
-            if (left == null || right == null || !comparator(left, right)) {
+            if (rightValue == null) {
                 return undefined;
             }
 
-            return { left, right };
+            return { left: leftValue, right: rightValue };
         }
     );
 
-    return List(_.compact(zipped));
+    return List(_.compact(grouped));
 };
 
 const hasValues = <T extends any[] | List<any> = any[] | List<any>>(


### PR DESCRIPTION
This fixes a bug where uploaded `Files` were not being rendered in the `FileList` component due to a bug in the `groupBy` implementation. I added some tests to ensure this behavior works as expected, plus `jest-extended` for additional matchers.

Fixes #109 