### PR TITLE
Unsolo tracks when sequencer opened

### DIFF
--- a/src/components/tracks/track-section-card/track-section-card.tsx
+++ b/src/components/tracks/track-section-card/track-section-card.tsx
@@ -28,6 +28,7 @@ import { InstrumentRecord } from "models/instrument-record";
 import { TrackSectionStepGrid } from "components/tracks/track-section-card/track-section-step-grid";
 import { TrackSectionStepColumnWidth } from "components/tracks/track-section-card/track-section-step-column";
 import { useWorkstationState } from "utils/hooks/use-workstation-state";
+import { unsoloAll } from "utils/track-utils";
 
 interface TrackSectionCardProps {
     file?: FileRecord;
@@ -45,13 +46,13 @@ const TrackSectionCard: React.FC<TrackSectionCardProps> = (
 ) => {
     const [
         sequencerDialogOpen,
-        handleOpenSequencerDialog,
+        openSequencerDialog,
         handleCloseSequencerDialog,
     ] = useDialog();
 
     const [
         pianoRollDialogOpen,
-        handleOpenPianoRollDialog,
+        openPianoRollDialog,
         handleClosePianoRollDialog,
     ] = useDialog();
 
@@ -75,7 +76,8 @@ const TrackSectionCard: React.FC<TrackSectionCardProps> = (
         trackId: trackSection.track_id,
     });
 
-    const { state: workstationState } = useWorkstationState();
+    const { state: workstationState, setCurrentState: setWorkstationState } =
+        useWorkstationState();
     const stepCount = workstationState.getStepCount();
     const { isSelected, onSelect } = useClipboardState();
 
@@ -85,6 +87,23 @@ const TrackSectionCard: React.FC<TrackSectionCardProps> = (
     } = useTrackSectionStepsState({ trackSectionId: trackSection.id });
     const { resultObject: files } = useListFiles();
     const theme = useTheme();
+
+    const unsoloTracks = useCallback(() => {
+        setWorkstationState((prev) => {
+            const { tracks } = prev;
+            return prev.merge({ tracks: unsoloAll(tracks) });
+        });
+    }, [setWorkstationState]);
+
+    const handleOpenSequencerDialog = useCallback(() => {
+        unsoloTracks();
+        openSequencerDialog();
+    }, [openSequencerDialog, unsoloTracks]);
+
+    const handleOpenPianoRollDialog = useCallback(() => {
+        unsoloTracks();
+        openPianoRollDialog();
+    }, [openPianoRollDialog, unsoloTracks]);
 
     const handleRemove = useCallback(
         () => remove(trackSection),

--- a/src/utils/track-utils.ts
+++ b/src/utils/track-utils.ts
@@ -1,14 +1,7 @@
 import { List } from "immutable";
-import { ProjectRecord } from "models/project-record";
 import { TrackRecord } from "models/track-record";
 
-const TrackUtils = {
-    getByProject(
-        project: ProjectRecord,
-        tracks: List<TrackRecord>
-    ): List<TrackRecord> {
-        return tracks.filter((track) => track.project_id === project.id);
-    },
-};
+const unsoloAll = (tracks: List<TrackRecord>): List<TrackRecord> =>
+    tracks.map((track) => track.merge({ solo: false }));
 
-export { TrackUtils };
+export { unsoloAll };


### PR DESCRIPTION
Fixes #71 

This change removes the `solo` status from all `Tracks` in state. While this is not ideal, it fixes the issue. The better solution would be figuring out how to maintain the solo status of the `Tracks` in the workstation while allowing audio to play properly in the Sequencer/Piano Roll dialogs, but I'm not sure it's worth the effort to investigate further right now.