### PR TITLE
Reset password page/feature

### DIFF
--- a/src/components/change-password-form.tsx
+++ b/src/components/change-password-form.tsx
@@ -1,14 +1,101 @@
-import { Pane, Text } from "evergreen-ui";
+import { ErrorAlert } from "components/error-alert";
+import { Flex } from "components/flex";
+import { Form } from "components/forms/form";
+import { ErrorMessages } from "constants/error-messages";
+import {
+    Alert,
+    Button,
+    Heading,
+    majorScale,
+    TextInputField,
+} from "evergreen-ui";
+import { ChangeEvent, useCallback } from "react";
+import { isNotFoundError } from "utils/error-utils";
+import { useInput } from "utils/hooks/use-input";
 
 interface ChangePasswordFormProps {}
 
 const ChangePasswordForm: React.FC<ChangePasswordFormProps> = (
     props: ChangePasswordFormProps
 ) => {
+    const {
+        value: password,
+        onChange: handlePasswordChange,
+        ...passwordValidation
+    } = useInput({ isRequired: true });
+
+    const {
+        value: passwordConfirmation,
+        onChange: onPasswordConfirmationChange,
+        setValidation: setPasswordConfirmationValidation,
+        ...passwordConfirmationValidation
+    } = useInput({ isRequired: true });
+
+    const handlePasswordConfirmationChange = useCallback(
+        (event: ChangeEvent<HTMLInputElement>) => {
+            const { value } = event.target;
+            onPasswordConfirmationChange(event);
+            const passwordsDoNotMatch =
+                password != null &&
+                password.length < value.length &&
+                value !== password;
+
+            if (!passwordsDoNotMatch) {
+                return;
+            }
+
+            setPasswordConfirmationValidation({
+                isInvalid: true,
+                validationMessage: ErrorMessages.PASSWORDS_DO_NOT_MATCH,
+            });
+        },
+        [
+            onPasswordConfirmationChange,
+            password,
+            setPasswordConfirmationValidation,
+        ]
+    );
+
+    const isLoading = false;
+    const isSuccess = false;
+    const error = null;
+
+    const handleSubmit = useCallback((event: React.FormEvent) => {
+        event.preventDefault();
+    }, []);
+
     return (
-        <Pane>
-            <Text>Change Password Form</Text>
-        </Pane>
+        <Flex.Column alignItems="center" maxWidth={majorScale(60)}>
+            <Heading marginBottom={majorScale(2)} size={800}>
+                Change your password
+            </Heading>
+            <Form onSubmit={handleSubmit} width={majorScale(30)}>
+                <TextInputField
+                    {...passwordValidation}
+                    label="Password"
+                    onChange={handlePasswordChange}
+                    type="password"
+                    value={password}
+                />
+                <TextInputField
+                    {...passwordConfirmationValidation}
+                    label="Confirm Password"
+                    onChange={handlePasswordConfirmationChange}
+                    type="password"
+                    value={passwordConfirmation}
+                />
+                <Button
+                    disabled={
+                        passwordValidation?.isInvalid ||
+                        passwordConfirmationValidation.isInvalid
+                    }
+                    isLoading={isLoading}
+                    onClick={handleSubmit}
+                    width="100%">
+                    Change Password
+                </Button>
+            </Form>
+        </Flex.Column>
     );
 };
 

--- a/src/components/change-password-form.tsx
+++ b/src/components/change-password-form.tsx
@@ -2,9 +2,17 @@ import { ErrorAlert } from "components/error-alert";
 import { Flex } from "components/flex";
 import { Form } from "components/forms/form";
 import { ErrorMessages } from "constants/error-messages";
-import { Button, Heading, majorScale, TextInputField } from "evergreen-ui";
+import {
+    Button,
+    Heading,
+    majorScale,
+    TextInputField,
+    toaster,
+} from "evergreen-ui";
 import { isEmpty } from "lodash";
 import { ChangeEvent, useCallback } from "react";
+import { useNavigate } from "react-router";
+import { Sitemap } from "sitemap";
 import { useChangePassword } from "utils/hooks/supabase/use-change-password";
 import { useInput } from "utils/hooks/use-input";
 import { ResetPasswordQueryParams } from "utils/hooks/use-reset-password-route";
@@ -16,6 +24,7 @@ const ChangePasswordForm: React.FC<ChangePasswordFormProps> = (
     props: ChangePasswordFormProps
 ) => {
     const { access_token } = props;
+    const navigate = useNavigate();
     const {
         value: password,
         onChange: handlePasswordChange,
@@ -29,7 +38,18 @@ const ChangePasswordForm: React.FC<ChangePasswordFormProps> = (
         ...passwordConfirmationValidation
     } = useInput({ isRequired: true });
 
-    const { isLoading, error, mutate: changePassword } = useChangePassword();
+    const handleChangePasswordSuccess = useCallback(() => {
+        toaster.success("Password successfully updated!");
+        navigate(Sitemap.home);
+    }, [navigate]);
+
+    const {
+        isLoading,
+        error,
+        mutate: changePassword,
+    } = useChangePassword({
+        onSuccess: handleChangePasswordSuccess,
+    });
 
     const handlePasswordConfirmationChange = useCallback(
         (event: ChangeEvent<HTMLInputElement>) => {

--- a/src/components/change-password-form.tsx
+++ b/src/components/change-password-form.tsx
@@ -1,0 +1,15 @@
+import { Pane, Text } from "evergreen-ui";
+
+interface ChangePasswordFormProps {}
+
+const ChangePasswordForm: React.FC<ChangePasswordFormProps> = (
+    props: ChangePasswordFormProps
+) => {
+    return (
+        <Pane>
+            <Text>Change Password Form</Text>
+        </Pane>
+    );
+};
+
+export { ChangePasswordForm };

--- a/src/components/login-or-register-form.tsx
+++ b/src/components/login-or-register-form.tsx
@@ -17,14 +17,14 @@ import { useCallback, useMemo } from "react";
 import { isNilOrEmpty } from "utils/core-utils";
 import { Flex } from "components/flex";
 
-interface LoginOrRegisterProps {
+interface LoginOrRegisterFormProps {
     initialShowRegister: boolean;
 }
 
 const marginBottom = majorScale(3);
 
-const LoginOrRegister: React.FC<LoginOrRegisterProps> = (
-    props: LoginOrRegisterProps
+const LoginOrRegisterForm: React.FC<LoginOrRegisterFormProps> = (
+    props: LoginOrRegisterFormProps
 ) => {
     const { initialShowRegister } = props;
     const { value: showRegister, toggle: toggleShowRegister } =
@@ -152,4 +152,4 @@ const LoginOrRegister: React.FC<LoginOrRegisterProps> = (
     );
 };
 
-export { LoginOrRegister };
+export { LoginOrRegisterForm };

--- a/src/components/login-or-register-form.tsx
+++ b/src/components/login-or-register-form.tsx
@@ -12,7 +12,7 @@ import { useBoolean } from "utils/hooks/use-boolean";
 import { useLogin } from "utils/hooks/supabase/use-login";
 import { useRegister } from "utils/hooks/supabase/use-register";
 import { Form } from "components/forms/form";
-import { useCallback, useMemo } from "react";
+import { FormEvent, MouseEvent, useCallback, useMemo } from "react";
 import { isNilOrEmpty } from "utils/core-utils";
 import { Flex } from "components/flex";
 import { SupabaseUser } from "types/supabase-user";
@@ -20,7 +20,10 @@ import { UserRecord } from "models/user-record";
 import { useCreateOrUpdateUser } from "generated/hooks/domain/users/use-create-or-update-user";
 import { useGlobalState } from "utils/hooks/use-global-state";
 import { useNavigate } from "react-router";
+import { Link as ReactRouterLink } from "react-router-dom";
 import { Sitemap } from "sitemap";
+import { ErrorAlert } from "components/error-alert";
+import { absolutePath } from "utils/route-utils";
 
 interface LoginOrRegisterFormProps {
     initialShowRegister: boolean;
@@ -87,21 +90,30 @@ const LoginOrRegisterForm: React.FC<LoginOrRegisterFormProps> = (
         return isValid;
     }, [email, password, setEmailIsInvalid, setPasswordIsInvalid]);
 
-    const handleLogin = useCallback(() => {
-        if (!validate()) {
-            return;
-        }
+    const handleLogin = useCallback(
+        (event: FormEvent<HTMLFormElement> | MouseEvent<HTMLButtonElement>) => {
+            event.preventDefault();
+            if (!validate()) {
+                return;
+            }
 
-        login({ email, password });
-    }, [email, login, password, validate]);
+            login({ email, password });
+        },
+        [email, login, password, validate]
+    );
 
-    const handleRegister = useCallback(() => {
-        if (!validate()) {
-            return;
-        }
+    const handleRegister = useCallback(
+        (event: FormEvent<HTMLFormElement> | MouseEvent<HTMLButtonElement>) => {
+            event.preventDefault();
 
-        register({ email, password });
-    }, [email, password, register, validate]);
+            if (!validate()) {
+                return;
+            }
+
+            register({ email, password });
+        },
+        [email, password, register, validate]
+    );
 
     const handleSubmit = useMemo(
         () => (showRegister ? handleRegister : handleLogin),
@@ -158,8 +170,14 @@ const LoginOrRegisterForm: React.FC<LoginOrRegisterFormProps> = (
                 <Link marginBottom={marginBottom} onClick={toggleAndReset}>
                     {toggleLinkText}
                 </Link>
+                <Link
+                    is={ReactRouterLink}
+                    marginBottom={marginBottom}
+                    to={absolutePath(Sitemap.resetPassword)}>
+                    Forgot your password?
+                </Link>
             </Form>
-            {renderError && <Alert intent="danger">{error?.message}</Alert>}
+            {renderError && <ErrorAlert error={error} />}
             {isRegisterSuccess && showRegister && (
                 <Alert intent="success" title="Account successfully created.">
                     Check your email for a confirmation link to sign in.

--- a/src/components/login-or-register-form.tsx
+++ b/src/components/login-or-register-form.tsx
@@ -1,4 +1,3 @@
-import { ErrorMessages } from "constants/error-messages";
 import {
     TextInputField,
     majorScale,
@@ -39,16 +38,22 @@ const LoginOrRegisterForm: React.FC<LoginOrRegisterFormProps> = (
     const navigate = useNavigate();
     const { value: showRegister, toggle: toggleShowRegister } =
         useBoolean(initialShowRegister);
-    const { value: email, onChange: handleEmailChange } = useInput({
+    const {
+        value: email,
+        onChange: handleEmailChange,
+        ...emailValidation
+    } = useInput({
         initialValue: "",
+        isRequired: true,
     });
-    const { value: password, onChange: handlePasswordChange } = useInput({
+    const {
+        value: password,
+        onChange: handlePasswordChange,
+        ...passwordValidation
+    } = useInput({
         initialValue: "",
+        isRequired: true,
     });
-    const { value: emailIsInvalid, setValue: setEmailIsInvalid } =
-        useBoolean(false);
-    const { value: passwordIsInvalid, setValue: setPasswordIsInvalid } =
-        useBoolean(false);
     const { mutate: createOrUpdateUser } = useCreateOrUpdateUser({
         onConflict: "id",
     });
@@ -87,12 +92,8 @@ const LoginOrRegisterForm: React.FC<LoginOrRegisterFormProps> = (
         const emailIsInvalid = isNilOrEmpty(email);
         const passwordIsInvalid = isNilOrEmpty(password);
         const isValid = !emailIsInvalid && !passwordIsInvalid;
-
-        setEmailIsInvalid(emailIsInvalid);
-        setPasswordIsInvalid(passwordIsInvalid);
-
         return isValid;
-    }, [email, password, setEmailIsInvalid, setPasswordIsInvalid]);
+    }, [email, password]);
 
     const handleLogin = useCallback(
         (event: FormEvent<HTMLFormElement> | MouseEvent<HTMLButtonElement>) => {
@@ -141,26 +142,18 @@ const LoginOrRegisterForm: React.FC<LoginOrRegisterFormProps> = (
                 onSubmit={handleSubmit}
                 width={majorScale(30)}>
                 <TextInputField
+                    {...emailValidation}
                     disabled={showRegister ? isRegisterLoading : isLoginLoading}
                     label="Email"
                     onChange={handleEmailChange}
-                    validationMessage={
-                        emailIsInvalid
-                            ? ErrorMessages.REQUIRED_FIELD
-                            : undefined
-                    }
                     value={email}
                 />
                 <TextInputField
+                    {...passwordValidation}
                     disabled={showRegister ? isRegisterLoading : isLoginLoading}
                     label="Password"
                     onChange={handlePasswordChange}
                     type="password"
-                    validationMessage={
-                        passwordIsInvalid
-                            ? ErrorMessages.REQUIRED_FIELD
-                            : undefined
-                    }
                     value={password}
                 />
                 <Button

--- a/src/components/login-or-register-form.tsx
+++ b/src/components/login-or-register-form.tsx
@@ -7,7 +7,6 @@ import {
     Link,
     Heading,
 } from "evergreen-ui";
-import { useInput } from "rooks";
 import { useBoolean } from "utils/hooks/use-boolean";
 import { useLogin } from "utils/hooks/supabase/use-login";
 import { useRegister } from "utils/hooks/supabase/use-register";
@@ -24,6 +23,7 @@ import { Link as ReactRouterLink } from "react-router-dom";
 import { Sitemap } from "sitemap";
 import { ErrorAlert } from "components/error-alert";
 import { absolutePath } from "utils/route-utils";
+import { useInput } from "utils/hooks/use-input";
 
 interface LoginOrRegisterFormProps {
     initialShowRegister: boolean;
@@ -39,8 +39,12 @@ const LoginOrRegisterForm: React.FC<LoginOrRegisterFormProps> = (
     const navigate = useNavigate();
     const { value: showRegister, toggle: toggleShowRegister } =
         useBoolean(initialShowRegister);
-    const { value: email, onChange: handleEmailChange } = useInput("");
-    const { value: password, onChange: handlePasswordChange } = useInput("");
+    const { value: email, onChange: handleEmailChange } = useInput({
+        initialValue: "",
+    });
+    const { value: password, onChange: handlePasswordChange } = useInput({
+        initialValue: "",
+    });
     const { value: emailIsInvalid, setValue: setEmailIsInvalid } =
         useBoolean(false);
     const { value: passwordIsInvalid, setValue: setPasswordIsInvalid } =
@@ -97,7 +101,7 @@ const LoginOrRegisterForm: React.FC<LoginOrRegisterFormProps> = (
                 return;
             }
 
-            login({ email, password });
+            login({ email: email!, password: password! });
         },
         [email, login, password, validate]
     );
@@ -110,7 +114,7 @@ const LoginOrRegisterForm: React.FC<LoginOrRegisterFormProps> = (
                 return;
             }
 
-            register({ email, password });
+            register({ email: email!, password: password! });
         },
         [email, password, register, validate]
     );

--- a/src/components/login-or-register.tsx
+++ b/src/components/login-or-register.tsx
@@ -123,9 +123,8 @@ const LoginOrRegister: React.FC<LoginOrRegisterProps> = (
             </Link>
             {renderError && <Alert intent="danger">{error?.message}</Alert>}
             {isRegisterSuccess && showRegister && (
-                <Alert intent="success">
-                    Account successfully created. Check your email for a
-                    confirmation link to sign in.
+                <Alert intent="success" title="Account successfully created.">
+                    Check your email for a confirmation link to sign in.
                 </Alert>
             )}
         </Form>

--- a/src/components/login-or-register.tsx
+++ b/src/components/login-or-register.tsx
@@ -1,11 +1,21 @@
 import { ErrorMessages } from "constants/error-messages";
-import { TextInputField, majorScale, Button, Alert, Link } from "evergreen-ui";
+import {
+    TextInputField,
+    majorScale,
+    Button,
+    Alert,
+    Link,
+    Heading,
+} from "evergreen-ui";
 import _ from "lodash";
 import { useInput } from "rooks";
 import { useBoolean } from "utils/hooks/use-boolean";
 import { useLogin } from "utils/hooks/supabase/use-login";
 import { useRegister } from "utils/hooks/supabase/use-register";
 import { Form } from "components/forms/form";
+import { useCallback, useMemo } from "react";
+import { isNilOrEmpty } from "utils/core-utils";
+import { Flex } from "components/flex";
 
 interface LoginOrRegisterProps {
     initialShowRegister: boolean;
@@ -49,10 +59,7 @@ const LoginOrRegister: React.FC<LoginOrRegisterProps> = (
         ? "Already have an account? Login here"
         : "Need an account? Register here";
 
-    const isNilOrEmpty = (value?: string): boolean =>
-        _.isNil(value) || _.trim(value).length < 1;
-
-    const validate = (): boolean => {
+    const validate = useCallback((): boolean => {
         const emailIsInvalid = isNilOrEmpty(email);
         const passwordIsInvalid = isNilOrEmpty(password);
         const isValid = !emailIsInvalid && !passwordIsInvalid;
@@ -61,73 +68,87 @@ const LoginOrRegister: React.FC<LoginOrRegisterProps> = (
         setPasswordIsInvalid(passwordIsInvalid);
 
         return isValid;
-    };
+    }, [email, password, setEmailIsInvalid, setPasswordIsInvalid]);
 
-    const handleLogin = () => {
+    const handleLogin = useCallback(() => {
         if (!validate()) {
             return;
         }
 
         login({ email, password });
-    };
+    }, [email, login, password, validate]);
 
-    const handleRegister = () => {
+    const handleRegister = useCallback(() => {
         if (!validate()) {
             return;
         }
 
         register({ email, password });
-    };
+    }, [email, password, register, validate]);
 
-    const handleSubmit = showRegister ? handleRegister : handleLogin;
+    const handleSubmit = useMemo(
+        () => (showRegister ? handleRegister : handleLogin),
+        [handleLogin, handleRegister, showRegister]
+    );
 
-    const toggleAndReset = () => {
+    const toggleAndReset = useCallback(() => {
         toggleShowRegister();
         resetLogin();
         resetRegister();
-    };
+    }, [resetLogin, resetRegister, toggleShowRegister]);
 
     return (
-        <Form
-            display="flex"
-            flexDirection="column"
-            onSubmit={handleSubmit}
-            width={majorScale(30)}>
-            <TextInputField
-                disabled={showRegister ? isRegisterLoading : isLoginLoading}
-                label="Email"
-                onChange={handleEmailChange}
-                validationMessage={
-                    emailIsInvalid ? ErrorMessages.REQUIRED_FIELD : undefined
-                }
-                value={email}
-            />
-            <TextInputField
-                disabled={showRegister ? isRegisterLoading : isLoginLoading}
-                label="Password"
-                onChange={handlePasswordChange}
-                type="password"
-                validationMessage={
-                    passwordIsInvalid ? ErrorMessages.REQUIRED_FIELD : undefined
-                }
-                value={password}
-            />
-            <Button
-                isLoading={showRegister ? isRegisterLoading : isLoginLoading}
-                marginBottom={marginBottom}
-                onClick={handleSubmit}>
-                {buttonText}
-            </Button>
-            <Link marginBottom={marginBottom} onClick={toggleAndReset}>
-                {toggleLinkText}
-            </Link>
+        <Flex.Column alignItems="center" maxWidth={majorScale(60)}>
+            <Heading marginBottom={majorScale(2)} size={800}>
+                {showRegister ? "Register" : "Login"}
+            </Heading>
+            <Form
+                display="flex"
+                flexDirection="column"
+                onSubmit={handleSubmit}
+                width={majorScale(30)}>
+                <TextInputField
+                    disabled={showRegister ? isRegisterLoading : isLoginLoading}
+                    label="Email"
+                    onChange={handleEmailChange}
+                    validationMessage={
+                        emailIsInvalid
+                            ? ErrorMessages.REQUIRED_FIELD
+                            : undefined
+                    }
+                    value={email}
+                />
+                <TextInputField
+                    disabled={showRegister ? isRegisterLoading : isLoginLoading}
+                    label="Password"
+                    onChange={handlePasswordChange}
+                    type="password"
+                    validationMessage={
+                        passwordIsInvalid
+                            ? ErrorMessages.REQUIRED_FIELD
+                            : undefined
+                    }
+                    value={password}
+                />
+                <Button
+                    isLoading={
+                        showRegister ? isRegisterLoading : isLoginLoading
+                    }
+                    marginBottom={marginBottom}
+                    onClick={handleSubmit}>
+                    {buttonText}
+                </Button>
+                <Link marginBottom={marginBottom} onClick={toggleAndReset}>
+                    {toggleLinkText}
+                </Link>
+            </Form>
             {renderError && <Alert intent="danger">{error?.message}</Alert>}
             {isRegisterSuccess && showRegister && (
                 <Alert intent="success" title="Account successfully created.">
                     Check your email for a confirmation link to sign in.
                 </Alert>
             )}
-        </Form>
+        </Flex.Column>
     );
 };
 

--- a/src/components/pages/login-page.tsx
+++ b/src/components/pages/login-page.tsx
@@ -1,4 +1,4 @@
-import { LoginOrRegister } from "components/login-or-register";
+import { LoginOrRegisterForm } from "components/login-or-register-form";
 import { Pane } from "evergreen-ui";
 import { RouteProps } from "interfaces/route-props";
 
@@ -12,7 +12,7 @@ const LoginPage: React.FC<LoginPageProps> = (props: LoginPageProps) => {
             flexDirection="column"
             justifyContent="center"
             width="100%">
-            <LoginOrRegister initialShowRegister={false} />
+            <LoginOrRegisterForm initialShowRegister={false} />
         </Pane>
     );
 };

--- a/src/components/pages/not-found-page.tsx
+++ b/src/components/pages/not-found-page.tsx
@@ -1,0 +1,42 @@
+import { Flex } from "components/flex";
+import {
+    EmptyState,
+    GeosearchIcon,
+    majorScale,
+    Text,
+    Strong,
+} from "evergreen-ui";
+import { useLocation } from "react-router";
+import { useTheme } from "utils/hooks/use-theme";
+
+interface NotFoundPageProps {}
+
+const NotFoundPage: React.FC<NotFoundPageProps> = (
+    props: NotFoundPageProps
+) => {
+    const { colors } = useTheme();
+    const { pathname } = useLocation();
+    return (
+        <Flex.Row alignItems="center" justifyContent="center" width="100%">
+            <Flex.Column maxHeight={majorScale(26)} maxWidth={majorScale(100)}>
+                <EmptyState
+                    background="dark"
+                    description={
+                        (
+                            <Text>
+                                {"The requested route "}
+                                <Strong>{pathname}</Strong>
+                                {" was not found."}
+                            </Text>
+                        ) as any
+                    }
+                    icon={<GeosearchIcon color={colors.gray600} />}
+                    iconBgColor={colors.gray400}
+                    title="Page Not Found"
+                />
+            </Flex.Column>
+        </Flex.Row>
+    );
+};
+
+export { NotFoundPage };

--- a/src/components/pages/not-found-page.tsx
+++ b/src/components/pages/not-found-page.tsx
@@ -17,7 +17,11 @@ const NotFoundPage: React.FC<NotFoundPageProps> = (
     const { colors } = useTheme();
     const { pathname } = useLocation();
     return (
-        <Flex.Row alignItems="center" justifyContent="center" width="100%">
+        <Flex.Row
+            alignItems="center"
+            justifyContent="center"
+            padding={majorScale(4)}
+            width="100%">
             <Flex.Column maxHeight={majorScale(26)} maxWidth={majorScale(100)}>
                 <EmptyState
                     background="dark"

--- a/src/components/pages/register-page.tsx
+++ b/src/components/pages/register-page.tsx
@@ -1,4 +1,4 @@
-import { LoginOrRegister } from "components/login-or-register";
+import { LoginOrRegisterForm } from "components/login-or-register-form";
 import { Pane } from "evergreen-ui";
 import { RouteProps } from "interfaces/route-props";
 
@@ -14,7 +14,7 @@ const RegisterPage: React.FC<RegisterPageProps> = (
             flexDirection="column"
             justifyContent="center"
             width="100%">
-            <LoginOrRegister initialShowRegister={true} />
+            <LoginOrRegisterForm initialShowRegister={true} />
         </Pane>
     );
 };

--- a/src/components/pages/reset-password-page.tsx
+++ b/src/components/pages/reset-password-page.tsx
@@ -1,15 +1,48 @@
+import { ChangePasswordForm } from "components/change-password-form";
 import { Flex } from "components/flex";
 import { ResetPasswordForm } from "components/reset-password-form";
+import { EmptyState, ErrorIcon } from "evergreen-ui";
 import { RouteProps } from "interfaces/route-props";
+import { isEmpty } from "lodash";
+import { isNotFoundError } from "utils/error-utils";
+import { useResetPasswordRoute } from "utils/hooks/use-reset-password-route";
+import { useTheme } from "utils/hooks/use-theme";
 
 interface ResetPasswordPageProps extends RouteProps {}
+
+const RECOVERY_TYPE = "recovery";
 
 const ResetPasswordPage: React.FC<ResetPasswordPageProps> = (
     props: ResetPasswordPageProps
 ) => {
+    const { intents } = useTheme();
+    const { access_token, error_description, clear, type } =
+        useResetPasswordRoute();
+    const showPasswordChangeForm =
+        !isEmpty(access_token) && type === RECOVERY_TYPE;
+    const showExpiredToken = isNotFoundError(error_description);
+    const showResetPasswordForm = !showPasswordChangeForm && !showExpiredToken;
+
     return (
         <Flex.Column alignItems="center" justifyContent="center" width="100%">
-            <ResetPasswordForm />
+            {showPasswordChangeForm && <ChangePasswordForm />}
+            {showExpiredToken && (
+                <Flex.Column alignItems="center">
+                    <EmptyState
+                        background="dark"
+                        description="The token is invalid or has expired. Request a new token to finish resetting your password."
+                        icon={<ErrorIcon color={intents.danger.icon} />}
+                        iconBgColor={intents.danger.background}
+                        primaryCta={
+                            <EmptyState.PrimaryButton onClick={clear}>
+                                Reset Password
+                            </EmptyState.PrimaryButton>
+                        }
+                        title="Invalid Token"
+                    />
+                </Flex.Column>
+            )}
+            {showResetPasswordForm && <ResetPasswordForm />}
         </Flex.Column>
     );
 };

--- a/src/components/pages/reset-password-page.tsx
+++ b/src/components/pages/reset-password-page.tsx
@@ -1,6 +1,5 @@
 import { Flex } from "components/flex";
 import { ResetPasswordForm } from "components/reset-password-form";
-import { Heading, majorScale } from "evergreen-ui";
 import { RouteProps } from "interfaces/route-props";
 
 interface ResetPasswordPageProps extends RouteProps {}
@@ -10,9 +9,6 @@ const ResetPasswordPage: React.FC<ResetPasswordPageProps> = (
 ) => {
     return (
         <Flex.Column alignItems="center" justifyContent="center" width="100%">
-            <Heading marginBottom={majorScale(2)} size={800}>
-                Reset your password
-            </Heading>
             <ResetPasswordForm />
         </Flex.Column>
     );

--- a/src/components/pages/reset-password-page.tsx
+++ b/src/components/pages/reset-password-page.tsx
@@ -1,7 +1,7 @@
 import { ChangePasswordForm } from "components/change-password-form";
 import { Flex } from "components/flex";
 import { ResetPasswordForm } from "components/reset-password-form";
-import { EmptyState, ErrorIcon } from "evergreen-ui";
+import { EmptyState, ErrorIcon, majorScale } from "evergreen-ui";
 import { RouteProps } from "interfaces/route-props";
 import { isEmpty } from "lodash";
 import { isNotFoundError } from "utils/error-utils";
@@ -29,7 +29,7 @@ const ResetPasswordPage: React.FC<ResetPasswordPageProps> = (
                 <ChangePasswordForm access_token={access_token} />
             )}
             {showExpiredToken && (
-                <Flex.Column alignItems="center">
+                <Flex.Column alignItems="center" padding={majorScale(4)}>
                     <EmptyState
                         background="dark"
                         description="The token is invalid or has expired. Request a new token to finish resetting your password."

--- a/src/components/pages/reset-password-page.tsx
+++ b/src/components/pages/reset-password-page.tsx
@@ -25,7 +25,9 @@ const ResetPasswordPage: React.FC<ResetPasswordPageProps> = (
 
     return (
         <Flex.Column alignItems="center" justifyContent="center" width="100%">
-            {showPasswordChangeForm && <ChangePasswordForm />}
+            {showPasswordChangeForm && (
+                <ChangePasswordForm access_token={access_token} />
+            )}
             {showExpiredToken && (
                 <Flex.Column alignItems="center">
                     <EmptyState

--- a/src/components/pages/reset-password-page.tsx
+++ b/src/components/pages/reset-password-page.tsx
@@ -1,0 +1,21 @@
+import { Flex } from "components/flex";
+import { ResetPasswordForm } from "components/reset-password-form";
+import { Heading, majorScale } from "evergreen-ui";
+import { RouteProps } from "interfaces/route-props";
+
+interface ResetPasswordPageProps extends RouteProps {}
+
+const ResetPasswordPage: React.FC<ResetPasswordPageProps> = (
+    props: ResetPasswordPageProps
+) => {
+    return (
+        <Flex.Column alignItems="center" justifyContent="center" width="100%">
+            <Heading marginBottom={majorScale(2)} size={800}>
+                Reset your password
+            </Heading>
+            <ResetPasswordForm />
+        </Flex.Column>
+    );
+};
+
+export { ResetPasswordPage };

--- a/src/components/reset-password-form.tsx
+++ b/src/components/reset-password-form.tsx
@@ -2,7 +2,13 @@ import { ErrorAlert } from "components/error-alert";
 import { Flex } from "components/flex";
 import { Form } from "components/forms/form";
 import { ErrorMessages } from "constants/error-messages";
-import { Alert, Button, majorScale, TextInputField } from "evergreen-ui";
+import {
+    Alert,
+    Button,
+    Heading,
+    majorScale,
+    TextInputField,
+} from "evergreen-ui";
 import { isEmpty } from "lodash";
 import { useCallback } from "react";
 import { useResetPassword } from "utils/hooks/supabase/use-reset-password";
@@ -40,6 +46,9 @@ const ResetPasswordForm: React.FC<ResetPasswordFormProps> = (
 
     return (
         <Flex.Column alignItems="center" maxWidth={majorScale(60)}>
+            <Heading marginBottom={majorScale(2)} size={800}>
+                Reset your password
+            </Heading>
             <Form onSubmit={handleSubmit} width={majorScale(30)}>
                 <TextInputField
                     {...emailValidation}

--- a/src/components/reset-password-form.tsx
+++ b/src/components/reset-password-form.tsx
@@ -13,12 +13,15 @@ import { isEmpty } from "lodash";
 import { useCallback } from "react";
 import { useResetPassword } from "utils/hooks/supabase/use-reset-password";
 import { useInput } from "utils/hooks/use-input";
+import { useResetPasswordRoute } from "utils/hooks/use-reset-password-route";
 
 interface ResetPasswordFormProps {}
 
 const ResetPasswordForm: React.FC<ResetPasswordFormProps> = (
     props: ResetPasswordFormProps
 ) => {
+    const { error_description } = useResetPasswordRoute();
+
     const {
         value: email,
         onChange: handleEmailChange,

--- a/src/components/reset-password-form.tsx
+++ b/src/components/reset-password-form.tsx
@@ -1,0 +1,28 @@
+import { Form } from "components/forms/form";
+import { majorScale, TextInputField } from "evergreen-ui";
+import { useInput } from "utils/hooks/use-input";
+
+interface ResetPasswordFormProps {}
+
+const ResetPasswordForm: React.FC<ResetPasswordFormProps> = (
+    props: ResetPasswordFormProps
+) => {
+    const {
+        value: email,
+        onChange: handleEmailChange,
+        ...emailValidation
+    } = useInput({ isRequired: true });
+
+    return (
+        <Form display="flex" flexDirection="column" width={majorScale(30)}>
+            <TextInputField
+                {...emailValidation}
+                label="Email"
+                onChange={handleEmailChange}
+                value={email}
+            />
+        </Form>
+    );
+};
+
+export { ResetPasswordForm };

--- a/src/components/reset-password-form.tsx
+++ b/src/components/reset-password-form.tsx
@@ -1,5 +1,11 @@
+import { ErrorAlert } from "components/error-alert";
+import { Flex } from "components/flex";
 import { Form } from "components/forms/form";
-import { majorScale, TextInputField } from "evergreen-ui";
+import { ErrorMessages } from "constants/error-messages";
+import { Alert, Button, majorScale, TextInputField } from "evergreen-ui";
+import { isEmpty } from "lodash";
+import { useCallback } from "react";
+import { useResetPassword } from "utils/hooks/supabase/use-reset-password";
 import { useInput } from "utils/hooks/use-input";
 
 interface ResetPasswordFormProps {}
@@ -12,17 +18,59 @@ const ResetPasswordForm: React.FC<ResetPasswordFormProps> = (
         onChange: handleEmailChange,
         ...emailValidation
     } = useInput({ isRequired: true });
+    const {
+        isLoading,
+        isSuccess,
+        error,
+        mutate: resetPassword,
+    } = useResetPassword();
+
+    const handleSubmit = useCallback(
+        (event: React.FormEvent) => {
+            event.preventDefault();
+
+            if (isEmpty(email)) {
+                return;
+            }
+
+            resetPassword(email!);
+        },
+        [email, resetPassword]
+    );
 
     return (
-        <Form display="flex" flexDirection="column" width={majorScale(30)}>
-            <TextInputField
-                {...emailValidation}
-                label="Email"
-                onChange={handleEmailChange}
-                value={email}
-            />
-        </Form>
+        <Flex.Column alignItems="center" maxWidth={majorScale(60)}>
+            <Form onSubmit={handleSubmit} width={majorScale(30)}>
+                <TextInputField
+                    {...emailValidation}
+                    label="Email"
+                    onChange={handleEmailChange}
+                    value={email}
+                />
+                <Button
+                    isLoading={isLoading}
+                    onClick={handleSubmit}
+                    width="100%">
+                    Reset Password
+                </Button>
+            </Form>
+            {error != null && !isNotFoundError(error) && (
+                <ErrorAlert error={error} />
+            )}
+            {(isSuccess || isNotFoundError(error)) && (
+                <Alert
+                    intent="success"
+                    marginTop={majorScale(2)}
+                    title="Password recovery started">
+                    If you have an account registered under this email address,
+                    you'll receive a link to reset your password.
+                </Alert>
+            )}
+        </Flex.Column>
     );
 };
+
+const isNotFoundError = (error: Error | null) =>
+    error != null && error.message === ErrorMessages.USER_NOT_FOUND;
 
 export { ResetPasswordForm };

--- a/src/components/reset-password-form.tsx
+++ b/src/components/reset-password-form.tsx
@@ -1,7 +1,6 @@
 import { ErrorAlert } from "components/error-alert";
 import { Flex } from "components/flex";
 import { Form } from "components/forms/form";
-import { ErrorMessages } from "constants/error-messages";
 import {
     Alert,
     Button,
@@ -12,7 +11,7 @@ import {
 import { isEmpty } from "lodash";
 import { useCallback } from "react";
 import { isNotFoundError } from "utils/error-utils";
-import { useResetPassword } from "utils/hooks/supabase/use-reset-password";
+import { useRequestPasswordReset } from "utils/hooks/supabase/use-request-password-reset";
 import { useInput } from "utils/hooks/use-input";
 
 interface ResetPasswordFormProps {}
@@ -29,8 +28,8 @@ const ResetPasswordForm: React.FC<ResetPasswordFormProps> = (
         isLoading,
         isSuccess,
         error,
-        mutate: resetPassword,
-    } = useResetPassword();
+        mutate: requestPasswordReset,
+    } = useRequestPasswordReset();
 
     const handleSubmit = useCallback(
         (event: React.FormEvent) => {
@@ -40,9 +39,9 @@ const ResetPasswordForm: React.FC<ResetPasswordFormProps> = (
                 return;
             }
 
-            resetPassword(email!);
+            requestPasswordReset(email!);
         },
-        [email, resetPassword]
+        [email, requestPasswordReset]
     );
 
     return (

--- a/src/components/reset-password-form.tsx
+++ b/src/components/reset-password-form.tsx
@@ -11,17 +11,15 @@ import {
 } from "evergreen-ui";
 import { isEmpty } from "lodash";
 import { useCallback } from "react";
+import { isNotFoundError } from "utils/error-utils";
 import { useResetPassword } from "utils/hooks/supabase/use-reset-password";
 import { useInput } from "utils/hooks/use-input";
-import { useResetPasswordRoute } from "utils/hooks/use-reset-password-route";
 
 interface ResetPasswordFormProps {}
 
 const ResetPasswordForm: React.FC<ResetPasswordFormProps> = (
     props: ResetPasswordFormProps
 ) => {
-    const { error_description } = useResetPasswordRoute();
-
     const {
         value: email,
         onChange: handleEmailChange,
@@ -81,8 +79,5 @@ const ResetPasswordForm: React.FC<ResetPasswordFormProps> = (
         </Flex.Column>
     );
 };
-
-const isNotFoundError = (error: Error | null) =>
-    error != null && error.message === ErrorMessages.USER_NOT_FOUND;
 
 export { ResetPasswordForm };

--- a/src/constants/error-messages.ts
+++ b/src/constants/error-messages.ts
@@ -2,6 +2,7 @@ const ErrorMessages = {
     EMAIL_NOT_CONFIRMED: "Email not confirmed",
     EMAIL_NOT_CONFIRMED_CHECK_EMAIL:
         "Email not confirmed. Check your email for a confirmation link to login.",
+    PASSWORDS_DO_NOT_MATCH: "Passwords do not match.",
     REQUIRED_FIELD: "This field is required.",
     USER_NOT_FOUND: "User not found",
 };

--- a/src/constants/error-messages.ts
+++ b/src/constants/error-messages.ts
@@ -3,6 +3,7 @@ const ErrorMessages = {
     EMAIL_NOT_CONFIRMED_CHECK_EMAIL:
         "Email not confirmed. Check your email for a confirmation link to login.",
     REQUIRED_FIELD: "This field is required.",
+    USER_NOT_FOUND: "User not found",
 };
 
 export { ErrorMessages };

--- a/src/models/global-state-record.ts
+++ b/src/models/global-state-record.ts
@@ -1,6 +1,9 @@
 import { Record } from "immutable";
 import { GlobalState } from "interfaces/global-state";
 import { BaseRecord } from "models/base-record";
+import { SupabaseUserRecord } from "models/supabase-user-record";
+import { UserRecord } from "models/user-record";
+import { SupabaseUser } from "types/supabase-user";
 import { makeDefaultValues } from "utils/core-utils";
 
 const defaultValues = makeDefaultValues<GlobalState>({
@@ -18,6 +21,17 @@ class GlobalStateRecord
 
     public userId(): string | undefined {
         return this.supabaseUser?.id ?? this.user?.id;
+    }
+
+    public setUser(supabaseUser?: SupabaseUser): GlobalStateRecord {
+        if (supabaseUser == null) {
+            return this.merge({ user: undefined, supabaseUser: undefined });
+        }
+
+        return this.merge({
+            user: UserRecord.fromSupabaseUser(supabaseUser),
+            supabaseUser: new SupabaseUserRecord(supabaseUser),
+        });
     }
 }
 

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -21,6 +21,7 @@ import { HelpLayout } from "components/layouts/help-layout";
 import { UsagePage } from "components/pages/usage-page";
 import { HelpResource } from "enums/help-resource";
 import { ResetPasswordPage } from "./components/pages/reset-password-page";
+import { NotFoundPage } from "components/pages/not-found-page";
 
 export interface RouteMap extends GenericRouteMap {
     root: RouteDefinition & {
@@ -125,6 +126,13 @@ const Routes: RouteMap = {
                         path: Sitemap.home,
                     },
                 },
+            },
+            notFound: {
+                element: <NotFoundPage />,
+                icon: HomeIcon,
+
+                name: "Not Found",
+                path: "*",
             },
         },
     },

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -20,6 +20,7 @@ import { InstrumentsPage } from "components/pages/instruments-page";
 import { HelpLayout } from "components/layouts/help-layout";
 import { UsagePage } from "components/pages/usage-page";
 import { HelpResource } from "enums/help-resource";
+import { ResetPasswordPage } from "./components/pages/reset-password-page";
 
 export interface RouteMap extends GenericRouteMap {
     root: RouteDefinition & {
@@ -106,6 +107,11 @@ const Routes: RouteMap = {
                 element: <RegisterPage />,
                 name: "Register",
                 path: Sitemap.register,
+            },
+            resetPassword: {
+                element: <ResetPasswordPage />,
+                name: "Reset Password",
+                path: Sitemap.resetPassword,
             },
             workstation: {
                 element: <WorkstationLayout />,

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -129,8 +129,6 @@ const Routes: RouteMap = {
             },
             notFound: {
                 element: <NotFoundPage />,
-                icon: HomeIcon,
-
                 name: "Not Found",
                 path: "*",
             },

--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -12,6 +12,7 @@ const Sitemap = {
     login: "login",
     logout: "logout",
     register: "register",
+    resetPassword: "reset-password",
 };
 
 export { Sitemap };

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -1,0 +1,13 @@
+import { ErrorMessages } from "constants/error-messages";
+
+export const isNotFoundError = (error?: Error | string | null): boolean => {
+    if (error == null) {
+        return false;
+    }
+
+    if (error instanceof Error) {
+        return error.message === ErrorMessages.USER_NOT_FOUND;
+    }
+
+    return error === ErrorMessages.USER_NOT_FOUND;
+};

--- a/src/utils/hooks/supabase/use-change-password.ts
+++ b/src/utils/hooks/supabase/use-change-password.ts
@@ -1,0 +1,34 @@
+import { UserAttributes } from "@supabase/supabase-js";
+import { useAuth } from "utils/hooks/supabase/use-auth";
+import { useMutation, UseMutationResult } from "utils/hooks/use-mutation";
+import { ResetPasswordQueryParams } from "utils/hooks/use-reset-password-route";
+
+interface ChangePasswordOptions
+    extends Pick<ResetPasswordQueryParams, "access_token">,
+        Pick<UserAttributes, "password"> {}
+
+interface UseChangePasswordResult
+    extends UseMutationResult<void, Error, ChangePasswordOptions> {}
+
+const useChangePassword = (): UseChangePasswordResult => {
+    const auth = useAuth();
+
+    const result = useMutation<void, Error, ChangePasswordOptions>({
+        fn: async (options: ChangePasswordOptions) => {
+            const { access_token, password } = options;
+            const updateResult = await auth.api.updateUser(access_token!, {
+                password,
+            });
+
+            const { error } = updateResult;
+            if (error != null) {
+                throw error;
+            }
+        },
+    });
+
+    return result;
+};
+
+export { useChangePassword };
+export type { ChangePasswordOptions, UseChangePasswordResult };

--- a/src/utils/hooks/supabase/use-change-password.ts
+++ b/src/utils/hooks/supabase/use-change-password.ts
@@ -7,10 +7,17 @@ interface ChangePasswordOptions
     extends Pick<ResetPasswordQueryParams, "access_token">,
         Pick<UserAttributes, "password"> {}
 
+interface UseChangePasswordOptions {
+    onSuccess?: () => void;
+}
+
 interface UseChangePasswordResult
     extends UseMutationResult<void, Error, ChangePasswordOptions> {}
 
-const useChangePassword = (): UseChangePasswordResult => {
+const useChangePassword = (
+    options?: UseChangePasswordOptions
+): UseChangePasswordResult => {
+    const { onSuccess } = options ?? {};
     const auth = useAuth();
 
     const result = useMutation<void, Error, ChangePasswordOptions>({
@@ -25,6 +32,7 @@ const useChangePassword = (): UseChangePasswordResult => {
                 throw error;
             }
         },
+        onSuccess,
     });
 
     return result;

--- a/src/utils/hooks/supabase/use-login.ts
+++ b/src/utils/hooks/supabase/use-login.ts
@@ -2,17 +2,18 @@ import { UserCredentials } from "interfaces/user-credentials";
 import { useAuth } from "utils/hooks/supabase/use-auth";
 import { useMutation } from "utils/hooks/use-mutation";
 import { ErrorMessages } from "constants/error-messages";
+import { SupabaseUser } from "types/supabase-user";
 
 interface UseLoginOptions {
     onError?: (error: Error) => void;
-    onSuccess?: () => void;
+    onSuccess?: (user: SupabaseUser) => void;
 }
 
 const useLogin = (options?: UseLoginOptions) => {
     const { onError, onSuccess } = options ?? {};
     const auth = useAuth();
 
-    const result = useMutation<void, Error, UserCredentials>({
+    const result = useMutation<SupabaseUser, Error, UserCredentials>({
         fn: async (credentials: UserCredentials) => {
             const { email, password, redirectTo } = credentials;
             const loginResult = await auth.signIn(
@@ -32,6 +33,8 @@ const useLogin = (options?: UseLoginOptions) => {
             if (error != null) {
                 throw error;
             }
+
+            return loginResult.user!;
         },
         onError,
         onSuccess,

--- a/src/utils/hooks/supabase/use-request-password-reset.ts
+++ b/src/utils/hooks/supabase/use-request-password-reset.ts
@@ -3,10 +3,10 @@ import { useAuth } from "utils/hooks/supabase/use-auth";
 import { useMutation, UseMutationResult } from "utils/hooks/use-mutation";
 import { joinPaths } from "utils/route-utils";
 
-interface UseResetPasswordResult
+interface UseRequestPasswordResetResult
     extends UseMutationResult<void, Error, string> {}
 
-const useResetPassword = (): UseResetPasswordResult => {
+const useRequestPasswordReset = (): UseRequestPasswordResetResult => {
     const auth = useAuth();
 
     const result = useMutation<void, Error, string>({
@@ -28,4 +28,4 @@ const useResetPassword = (): UseResetPasswordResult => {
     return result;
 };
 
-export { useResetPassword };
+export { useRequestPasswordReset };

--- a/src/utils/hooks/supabase/use-reset-password.ts
+++ b/src/utils/hooks/supabase/use-reset-password.ts
@@ -1,5 +1,7 @@
+import { Sitemap } from "sitemap";
 import { useAuth } from "utils/hooks/supabase/use-auth";
 import { useMutation, UseMutationResult } from "utils/hooks/use-mutation";
+import { joinPaths } from "utils/route-utils";
 
 interface UseResetPasswordResult
     extends UseMutationResult<void, Error, string> {}
@@ -9,7 +11,12 @@ const useResetPassword = (): UseResetPasswordResult => {
 
     const result = useMutation<void, Error, string>({
         fn: async (email: string) => {
-            const resetResult = await auth.api.resetPasswordForEmail(email);
+            const resetResult = await auth.api.resetPasswordForEmail(email, {
+                redirectTo: joinPaths(
+                    window.location.origin,
+                    Sitemap.resetPassword
+                ),
+            });
 
             const { error } = resetResult;
             if (error != null) {

--- a/src/utils/hooks/supabase/use-reset-password.ts
+++ b/src/utils/hooks/supabase/use-reset-password.ts
@@ -1,0 +1,24 @@
+import { useAuth } from "utils/hooks/supabase/use-auth";
+import { useMutation, UseMutationResult } from "utils/hooks/use-mutation";
+
+interface UseResetPasswordResult
+    extends UseMutationResult<void, Error, string> {}
+
+const useResetPassword = (): UseResetPasswordResult => {
+    const auth = useAuth();
+
+    const result = useMutation<void, Error, string>({
+        fn: async (email: string) => {
+            const resetResult = await auth.api.resetPasswordForEmail(email);
+
+            const { error } = resetResult;
+            if (error != null) {
+                throw error;
+            }
+        },
+    });
+
+    return result;
+};
+
+export { useResetPassword };

--- a/src/utils/hooks/supabase/use-subscribe-to-auth-status.ts
+++ b/src/utils/hooks/supabase/use-subscribe-to-auth-status.ts
@@ -1,71 +1,29 @@
 import { AuthChangeEvent, Session } from "@supabase/gotrue-js";
-import { GlobalStateRecord } from "models/global-state-record";
-import { SupabaseUserRecord } from "models/supabase-user-record";
 import { useCallback, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Sitemap } from "sitemap";
 import { useAuth } from "utils/hooks/supabase/use-auth";
 import { useGlobalState } from "utils/hooks/use-global-state";
-import { useCreateOrUpdateUser } from "generated/hooks/domain/users/use-create-or-update-user";
-import { UserRecord } from "models/user-record";
 import { toaster } from "evergreen-ui";
 
 const useSubscribeToAuthStatus = () => {
     const auth = useAuth();
     const { setGlobalState } = useGlobalState();
-    const { mutate: createOrUpdateUser } = useCreateOrUpdateUser({
-        onConflict: "id",
-    });
 
     const navigate = useNavigate();
 
-    const setUserFromSession = useCallback(
-        (session: Session | null) => {
-            if (session == null || session.user == null) {
-                setGlobalState((prev) =>
-                    prev.merge({ supabaseUser: undefined, user: undefined })
-                );
-
-                return;
-            }
-
-            const { user } = session;
-            setGlobalState((prev: GlobalStateRecord) =>
-                prev.merge({
-                    user: UserRecord.fromSupabaseUser(user),
-                    supabaseUser: new SupabaseUserRecord(user),
-                })
-            );
-        },
-        [setGlobalState]
-    );
-
     const handleAuthStateChange = useCallback(
         (event: AuthChangeEvent, session: Session | null) => {
-            if (event !== "SIGNED_IN" && event !== "SIGNED_OUT") {
+            if (event !== "SIGNED_OUT") {
                 return;
             }
 
-            if (event === "SIGNED_OUT") {
-                toaster.notify("You were signed out.");
-                setUserFromSession(null);
-                navigate(Sitemap.login);
-                return;
-            }
-
-            if (session?.user == null) {
-                return;
-            }
-
-            const { user: supabaseUser } = session;
-
-            // Ensure user is persisted on our side
-            const user = UserRecord.fromSupabaseUser(supabaseUser);
-            createOrUpdateUser(user);
-            setUserFromSession(session);
-            navigate(Sitemap.home);
+            toaster.notify("You were signed out.");
+            setGlobalState((prev) => prev.setUser(undefined));
+            navigate(Sitemap.login);
+            return;
         },
-        [createOrUpdateUser, navigate, setUserFromSession]
+        [navigate, setGlobalState]
     );
 
     useEffect(() => {

--- a/src/utils/hooks/use-reset-password-route.ts
+++ b/src/utils/hooks/use-reset-password-route.ts
@@ -1,9 +1,9 @@
 import { isEmpty, zip } from "lodash";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useLocation } from "react-router";
 import { useSearchParams } from "react-router-dom";
 
-interface UseResetPasswordRouteResult {
+interface ResetPasswordQueryParams {
     access_token?: string;
     error_code?: number;
     error_description?: string;
@@ -13,7 +13,11 @@ interface UseResetPasswordRouteResult {
     type?: string;
 }
 
-const keys: Array<keyof UseResetPasswordRouteResult> = [
+interface UseResetPasswordRouteResult extends ResetPasswordQueryParams {
+    clear: () => void;
+}
+
+const keys: Array<keyof ResetPasswordQueryParams> = [
     "access_token",
     "error_code",
     "error_description",
@@ -26,7 +30,8 @@ const keys: Array<keyof UseResetPasswordRouteResult> = [
 const useResetPasswordRoute = () => {
     const { hash } = useLocation();
     const [, setSearchParams] = useSearchParams();
-    const [result, setResult] = useState<UseResetPasswordRouteResult>({});
+    const [result, setResult] = useState<ResetPasswordQueryParams>({});
+    const clear = useCallback(() => setResult({}), []);
 
     useEffect(() => {
         if (isEmpty(hash)) {
@@ -36,7 +41,7 @@ const useResetPasswordRoute = () => {
         const searchParams = new URLSearchParams(hash.replace("#", ""));
         const values = keys.map((key) => searchParams.get(key) ?? undefined);
         setResult(
-            Object.fromEntries(zip(keys, values)) as UseResetPasswordRouteResult
+            Object.fromEntries(zip(keys, values)) as ResetPasswordQueryParams
         );
     }, [hash]);
 
@@ -48,7 +53,8 @@ const useResetPasswordRoute = () => {
         setSearchParams(new URLSearchParams());
     }, [hash, setSearchParams]);
 
-    return result;
+    return { ...result, clear };
 };
 
 export { useResetPasswordRoute };
+export type { ResetPasswordQueryParams, UseResetPasswordRouteResult };

--- a/src/utils/hooks/use-reset-password-route.ts
+++ b/src/utils/hooks/use-reset-password-route.ts
@@ -1,0 +1,54 @@
+import { isEmpty, zip } from "lodash";
+import { useEffect, useMemo, useState } from "react";
+import { useLocation } from "react-router";
+import { useSearchParams } from "react-router-dom";
+
+interface UseResetPasswordRouteResult {
+    access_token?: string;
+    error_code?: number;
+    error_description?: string;
+    expires_in?: string;
+    refresh_token?: string;
+    token_type?: string;
+    type?: string;
+}
+
+const keys: Array<keyof UseResetPasswordRouteResult> = [
+    "access_token",
+    "error_code",
+    "error_description",
+    "refresh_token",
+    "expires_in",
+    "token_type",
+    "type",
+];
+
+const useResetPasswordRoute = () => {
+    const { hash } = useLocation();
+    const [, setSearchParams] = useSearchParams();
+    const [result, setResult] = useState<UseResetPasswordRouteResult>({});
+
+    useEffect(() => {
+        if (isEmpty(hash)) {
+            return;
+        }
+
+        const searchParams = new URLSearchParams(hash.replace("#", ""));
+        const values = keys.map((key) => searchParams.get(key) ?? undefined);
+        setResult(
+            Object.fromEntries(zip(keys, values)) as UseResetPasswordRouteResult
+        );
+    }, [hash]);
+
+    useEffect(() => {
+        if (isEmpty(hash)) {
+            return;
+        }
+
+        setSearchParams(new URLSearchParams());
+    }, [hash, setSearchParams]);
+
+    return result;
+};
+
+export { useResetPasswordRoute };

--- a/src/utils/route-utils.ts
+++ b/src/utils/route-utils.ts
@@ -5,7 +5,9 @@ import {
     RouteObject,
     matchRoutes as reactRouterMatchRoutes,
 } from "react-router";
-import { flatMap, toLower } from "lodash";
+import { flatMap, isEmpty, toLower } from "lodash";
+
+const absolutePath = (path?: string) => (isEmpty(path) ? "/" : `/${path}`);
 
 const flattenRoutes = (routes?: RouteMap): RouteDefinition[] => {
     if (routes == null) {
@@ -36,4 +38,4 @@ const toRouteObject = (route: RouteDefinition): RouteObject => {
     };
 };
 
-export { flattenRoutes, joinPaths, matchRoutes, toRouteObject };
+export { absolutePath, flattenRoutes, joinPaths, matchRoutes, toRouteObject };


### PR DESCRIPTION
Resolves #144 

- Adds new route `/reset-password` for requesting a password change via email
![image](https://user-images.githubusercontent.com/11774799/162632962-55bce731-01e2-4619-8588-d5966fef2c7e.png)
    - This route doubles as the "Change Password" functionality when being redirected from the reset email
![image](https://user-images.githubusercontent.com/11774799/162633002-d8ef473c-10af-4363-af29-425398c52f83.png)
    - Invalid or expired tokens show an empty state to let the user know they need to request a new token
![image](https://user-images.githubusercontent.com/11774799/162633020-d205535a-07d9-4ba9-922e-bc05ce16d7aa.png)
- Email template has been added from https://codesandbox.io/s/beets-reset-password-template-wmu36x
- A new "Not Found" page has been added as a catch-all for any non-matching routes.
![image](https://user-images.githubusercontent.com/11774799/162633039-ff0a02e3-749d-47bf-97c4-bfd96285dd2b.png)
