### PR TITLE
Fix sample loading

### DIFF
--- a/src/components/instruments/instrument-settings.tsx
+++ b/src/components/instruments/instrument-settings.tsx
@@ -86,7 +86,7 @@ const InstrumentSettings: React.FC<InstrumentSettingsProps> = (
         setValidation: setNameValidation,
         ...nameValidation
     } = useInput({
-        initialValue: initialInstrument?.name,
+        initialValue: initialInstrument?.name ?? "",
     });
     const {
         displayValue: releaseDisplayValue,

--- a/src/components/sidebar/about-dialog.tsx
+++ b/src/components/sidebar/about-dialog.tsx
@@ -11,6 +11,7 @@ import React from "react";
 import { formatUpdatedOn } from "utils/date-utils";
 import { useLatestRelease } from "utils/hooks/use-latest-release";
 import { Dialog, DialogProps } from "components/dialog";
+import { isDevelopment } from "utils/env";
 
 enum Environment {
     Development = "Development",
@@ -74,7 +75,7 @@ const AboutDialog: React.FC<AboutDialogProps> = (props: AboutDialogProps) => {
 };
 
 const getCurrentEnvironment = (): Environment => {
-    if (process.env.NODE_ENV === "development") {
+    if (isDevelopment()) {
         return Environment.Local;
     }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,8 +7,10 @@ import { ThemeProvider } from "evergreen-ui";
 import { theme } from "theme";
 import "./index.css";
 import { registerIndexStyleMutation } from "utils/register-index-style-mutation";
+import { registerConsoleErrorToasts } from "utils/register-console-error-toasts";
 
 registerIndexStyleMutation();
+registerConsoleErrorToasts();
 
 const queryClient = new QueryClient({
     defaultOptions: {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -10,5 +10,7 @@ interface Environment extends NodeJS.ProcessEnv {
 
 const env: Environment = process.env;
 
-export { env };
+const isDevelopment = () => env.NODE_ENV === "development";
+
+export { env, isDevelopment };
 export type { Environment };

--- a/src/utils/register-console-error-toasts.ts
+++ b/src/utils/register-console-error-toasts.ts
@@ -1,0 +1,16 @@
+import { toaster } from "evergreen-ui";
+import { isDevelopment } from "utils/env";
+
+const registerConsoleErrorToasts = () => {
+    if (!isDevelopment()) {
+        return;
+    }
+
+    const consoleError = console.error;
+    console.error = (message: string, ...args: any[]) => {
+        consoleError(message, args);
+        toaster.danger(message, { id: [message, JSON.stringify(args)].join() });
+    };
+};
+
+export { registerConsoleErrorToasts };


### PR DESCRIPTION
Fixes #153 

The issue seems to be instantiating a new `Tone.Sampler` with an empty sample map (`{}`). The sampler/tone track doesn't seem to be properly updating or loading the sample once the instrument track has been added.

Additionally, adds a utility for displaying console error logs as toasts while in development. This will be annoying, but help weed out console errors that go under the radar.