### PR TITLE
Remember sample selections in SequencerDialog

### DIFF
--- a/src/components/select-menu.tsx
+++ b/src/components/select-menu.tsx
@@ -6,9 +6,9 @@ import {
     SelectMenuProps as EvergreenSelectMenuProps,
 } from "evergreen-ui";
 import { List } from "immutable";
-import _ from "lodash";
+import { intersectionWith, isArray, pick } from "lodash";
 import { useCallback, useMemo } from "react";
-import { isNotNilOrEmpty } from "utils/core-utils";
+import { isEqual, isNotNilOrEmpty } from "utils/core-utils";
 
 type FirstParameter<TFunction extends undefined | ((...args: any[]) => any)> =
     Parameters<NonNullable<TFunction>>[0];
@@ -59,7 +59,7 @@ const SelectMenu = <T,>(props: SelectMenuProps<T>) => {
     const options: EvergreenSelectMenuItem[] | undefined = useMemo(
         () =>
             optionValues?.map((optionValue) => ({
-                ..._.pick<SelectMenuItem<T>, keyof SelectMenuItem<T>>(
+                ...pick<SelectMenuItem<T>, keyof SelectMenuItem<T>>(
                     optionValue,
                     "disabled",
                     "label",
@@ -77,11 +77,11 @@ const SelectMenu = <T,>(props: SelectMenuProps<T>) => {
             _selectedValues = _selectedValues.toArray();
         }
 
-        if (_.isArray(_selectedValues)) {
-            return _.intersectionWith(
+        if (isArray(_selectedValues)) {
+            return intersectionWith(
                 optionValues,
                 _selectedValues,
-                (option, selected) => option.value === selected
+                (option, selected) => isEqual(option.value, selected)
             ).map((selected) => selected.id);
         }
 

--- a/src/components/sequencer/sequencer.tsx
+++ b/src/components/sequencer/sequencer.tsx
@@ -1,9 +1,8 @@
 import { SequencerStep } from "components/sequencer/sequencer-step";
-import { Button, majorScale, Pane } from "evergreen-ui";
+import { Button, CrossIcon, majorScale, Pane } from "evergreen-ui";
 import _ from "lodash";
 import { List } from "immutable";
 import { FileRecord } from "models/file-record";
-import { useCallback, useState } from "react";
 import pluralize from "pluralize";
 import { TrackSectionStepRecord } from "models/track-section-step-record";
 import { TrackSectionRecord } from "models/track-section-record";
@@ -14,6 +13,8 @@ import { PlayButton } from "components/workstation/play-button";
 import { useToneAudio } from "utils/hooks/use-tone-audio";
 import { TrackRecord } from "models/track-record";
 import { toDataAttributes } from "utils/data-attribute-utils";
+import { useSampleSelection } from "utils/hooks/use-sample-selection";
+import { IconButton } from "components/icon-button";
 
 interface SequencerProps {
     files: List<FileRecord>;
@@ -38,24 +39,11 @@ const Sequencer: React.FC<SequencerProps> = (props: SequencerProps) => {
         trackSection,
     } = props;
 
+    const { selected, onSelect, onDeselect, onClear } = useSampleSelection({
+        files,
+        track,
+    });
     const { value: isPlaying, toggle: toggleIsPlaying } = useBoolean();
-    const [selected, setSelected] = useState<List<FileRecord>>(List());
-
-    const handleDeselect = useCallback(
-        (file: FileRecord) =>
-            setSelected((prev) =>
-                prev.includes(file) ? prev.remove(prev.indexOf(file)) : prev
-            ),
-        [setSelected]
-    );
-
-    const handleSelect = useCallback(
-        (file: FileRecord) =>
-            setSelected((prev) =>
-                prev.includes(file) ? prev : prev.push(file)
-            ),
-        [setSelected]
-    );
 
     const { isLoading } = useToneAudio({
         isPlaying,
@@ -78,14 +66,24 @@ const Sequencer: React.FC<SequencerProps> = (props: SequencerProps) => {
                 />
                 <FileSelectMenu
                     isMultiSelect={true}
-                    onDeselect={handleDeselect}
-                    onSelect={handleSelect}
+                    onDeselect={onDeselect}
+                    onSelect={onSelect}
                     selected={selected}
                     title="Current Samples">
-                    <Button marginRight={buttonMarginRight}>
+                    <Button
+                        borderBottomRightRadius={0}
+                        borderTopRightRadius={0}>
                         {sampleButtonText}
                     </Button>
                 </FileSelectMenu>
+                <IconButton
+                    borderBottomLeftRadius={0}
+                    borderLeft="none"
+                    borderTopLeftRadius={0}
+                    icon={CrossIcon}
+                    marginRight={buttonMarginRight}
+                    onClick={onClear}
+                />
                 <StepCountSelectMenu
                     onChange={onStepCountChange}
                     stepCount={stepCount}

--- a/src/utils/atoms/global-state-atom.ts
+++ b/src/utils/atoms/global-state-atom.ts
@@ -4,7 +4,7 @@ import { GlobalStateRecord } from "models/global-state-record";
 const GlobalStateAtom = immutableAtomWithStorage<GlobalStateRecord>(
     "globalState",
     new GlobalStateRecord(),
-    GlobalStateRecord
+    (args) => new GlobalStateRecord(args)
 );
 
 export { GlobalStateAtom };

--- a/src/utils/atoms/immutable-atom-with-storage.ts
+++ b/src/utils/atoms/immutable-atom-with-storage.ts
@@ -1,19 +1,19 @@
-import { Record } from "immutable";
+import { Collection, Record } from "immutable";
 import { atomWithStorage } from "jotai/utils";
 
-const immutableAtomWithStorage = <T extends Record<any>>(
+const immutableAtomWithStorage = <T extends Record<any> | Collection<any, any>>(
     key: string,
     initialValue: T,
-    constructor: new (...args: any[]) => T
+    constructorOrFactory: (...args: any[]) => T
 ) =>
     atomWithStorage(key, initialValue, {
         getItem: (key: string) => {
             const value = localStorage.getItem(key);
             if (value == null) {
-                return new constructor();
+                return constructorOrFactory();
             }
 
-            return new constructor(JSON.parse(value));
+            return constructorOrFactory(JSON.parse(value));
         },
         removeItem: (key: string) => localStorage.removeItem(key),
         setItem: (key: string, newValue: T) =>

--- a/src/utils/atoms/sample-selection-atom.ts
+++ b/src/utils/atoms/sample-selection-atom.ts
@@ -1,0 +1,10 @@
+import { immutableAtomWithStorage } from "utils/atoms/immutable-atom-with-storage";
+import { Map, List } from "immutable";
+
+const SampleSelectionAtom = immutableAtomWithStorage<Map<string, List<string>>>(
+    "sampleSelection",
+    Map(),
+    Map
+);
+
+export { SampleSelectionAtom };

--- a/src/utils/core-utils.ts
+++ b/src/utils/core-utils.ts
@@ -1,7 +1,8 @@
 import { BorderPropsOptions } from "interfaces/border-props-options";
 import { BorderProps } from "interfaces/border-props";
 import { RequiredOrUndefined } from "types/required-or-undefined";
-import { List } from "immutable";
+import { List, Record } from "immutable";
+import { isEqual as lodashIsEqual } from "lodash";
 
 const getBorderYProps = (options: BorderPropsOptions): BorderProps => {
     const { isFirst = false, isLast = false, borderRadius } = options;
@@ -44,6 +45,20 @@ const getBorderXProps = (options: BorderPropsOptions): BorderProps => {
     return borderProps;
 };
 
+const isEqual = <
+    TLeft extends Record<any> | any,
+    TRight extends Record<any> | any
+>(
+    left: TLeft,
+    right: TRight
+): boolean => {
+    if (Record.isRecord(left) && Record.isRecord(right)) {
+        return left.equals(right);
+    }
+
+    return lodashIsEqual(left, right);
+};
+
 const isNilOrEmpty = <T = string | any[] | List<any>>(
     value: T | any[] | List<any> | null | undefined
 ): value is null | undefined => {
@@ -81,6 +96,7 @@ const unixTime = (date?: Date): number =>
 export {
     getBorderYProps,
     getBorderXProps,
+    isEqual,
     isNilOrEmpty,
     isNotNilOrEmpty,
     makeDefaultValues,

--- a/src/utils/hooks/use-sample-selection.ts
+++ b/src/utils/hooks/use-sample-selection.ts
@@ -6,7 +6,17 @@ import { useCallback, useEffect, useState } from "react";
 import { TrackRecord } from "models/track-record";
 
 interface UseSampleSelectionOptions {
+    /**
+     * List of files that can be selected
+     */
     files: List<FileRecord>;
+    /**
+     * Maximum number of samples to be selected at one time
+     */
+    maxSelected?: number;
+    /**
+     * Track that the samples will be associated with
+     */
     track: TrackRecord;
 }
 
@@ -20,7 +30,7 @@ interface UseSampleSelectionResult {
 const useSampleSelection = (
     options: UseSampleSelectionOptions
 ): UseSampleSelectionResult => {
-    const { files, track } = options;
+    const { files, maxSelected = 4, track } = options;
     const [sampleSelection, setSampleSelection] = useAtom(SampleSelectionAtom);
     const [selected, setSelected] = useState<List<FileRecord>>(
         getFilesFromSelectionMap(sampleSelection, track, files)
@@ -36,10 +46,14 @@ const useSampleSelection = (
 
     const onSelect = useCallback(
         (file: FileRecord) =>
-            setSelected((prev) =>
-                prev.includes(file) ? prev : prev.push(file)
-            ),
-        []
+            setSelected((prev) => {
+                if (maxSelected != null && prev.count() >= maxSelected) {
+                    return prev;
+                }
+
+                return prev.includes(file) ? prev : prev.push(file);
+            }),
+        [maxSelected]
     );
 
     const onClear = useCallback(() => {

--- a/src/utils/hooks/use-sample-selection.ts
+++ b/src/utils/hooks/use-sample-selection.ts
@@ -1,0 +1,71 @@
+import { useAtom } from "jotai";
+import { SampleSelectionAtom } from "utils/atoms/sample-selection-atom";
+import { List, Map } from "immutable";
+import { FileRecord } from "models/file-record";
+import { useCallback, useEffect, useState } from "react";
+import { TrackRecord } from "models/track-record";
+
+interface UseSampleSelectionOptions {
+    files: List<FileRecord>;
+    track: TrackRecord;
+}
+
+interface UseSampleSelectionResult {
+    onClear: () => void;
+    onDeselect: (file: FileRecord) => void;
+    onSelect: (file: FileRecord) => void;
+    selected: List<FileRecord>;
+}
+
+const useSampleSelection = (
+    options: UseSampleSelectionOptions
+): UseSampleSelectionResult => {
+    const { files, track } = options;
+    const [sampleSelection, setSampleSelection] = useAtom(SampleSelectionAtom);
+    const [selected, setSelected] = useState<List<FileRecord>>(
+        getFilesFromSelectionMap(sampleSelection, track, files)
+    );
+
+    const onDeselect = useCallback(
+        (file: FileRecord) =>
+            setSelected((prev) =>
+                prev.includes(file) ? prev.remove(prev.indexOf(file)) : prev
+            ),
+        []
+    );
+
+    const onSelect = useCallback(
+        (file: FileRecord) =>
+            setSelected((prev) =>
+                prev.includes(file) ? prev : prev.push(file)
+            ),
+        []
+    );
+
+    const onClear = useCallback(() => {
+        setSelected(List());
+    }, []);
+
+    useEffect(() => {
+        setSampleSelection((prev) =>
+            prev.set(
+                track.id,
+                selected.map((file) => file.id)
+            )
+        );
+    }, [selected, setSampleSelection, track.id]);
+
+    return { selected, onDeselect, onSelect, onClear };
+};
+
+const getFilesFromSelectionMap = (
+    sampleSelection: Map<string, List<string>>,
+    track: TrackRecord,
+    files: List<FileRecord>
+): List<FileRecord> => {
+    const fileIds = sampleSelection.get(track.id);
+
+    return files.filter((file) => fileIds?.includes(file.id)) ?? List();
+};
+
+export { useSampleSelection };


### PR DESCRIPTION
Closes #147

Samples selected in the Sequencer dialog will be persisted to local storage based on the related Track. When reopening the dialog for a track, the sample selection will be initialized based on the ids in local storage. 

Additionally, I added a button to the right of the sample selection dropdown to clear the selection. I think this is a nice-to-have either way - sometimes you can 'lose' or forget where a sample is in the list and it's easier to just clear it out.

Finally, I added a cap so that only 4 samples can be selected at a time. Since the Track Section Step will only accept up to 4 samples, this should prevent people from accidentally selecting too many samples to work with.