### PR TITLE
Swap ReactDOM.render with createRoot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
                 "@types/pluralize": "0.0.29",
                 "@types/react": "17.0.18",
                 "@types/react-beautiful-dnd": "13.1.2",
-                "@types/react-dom": "17.0.9",
+                "@types/react-dom": "18.0.1",
                 "@types/react-router-dom": "5.3.3",
                 "@types/uuid": "8.3.1",
                 "chalk": "4.1.2",
@@ -3719,9 +3719,9 @@
             }
         },
         "node_modules/@types/react-dom": {
-            "version": "17.0.9",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.9.tgz",
-            "integrity": "sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==",
+            "version": "18.0.1",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.1.tgz",
+            "integrity": "sha512-jCwTXvHtRLiyVvKm9aEdHXs8rflVOGd5Sl913JZrPshfXjn8NYsTNZOz70bCsA31IR0TOqwi3ad+X4tSCBoMTw==",
             "dev": true,
             "dependencies": {
                 "@types/react": "*"
@@ -26788,9 +26788,9 @@
             }
         },
         "@types/react-dom": {
-            "version": "17.0.9",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.9.tgz",
-            "integrity": "sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==",
+            "version": "18.0.1",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.1.tgz",
+            "integrity": "sha512-jCwTXvHtRLiyVvKm9aEdHXs8rflVOGd5Sl913JZrPshfXjn8NYsTNZOz70bCsA31IR0TOqwi3ad+X4tSCBoMTw==",
             "dev": true,
             "requires": {
                 "@types/react": "*"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "@types/pluralize": "0.0.29",
         "@types/react": "17.0.18",
         "@types/react-beautiful-dnd": "13.1.2",
-        "@types/react-dom": "17.0.9",
+        "@types/react-dom": "18.0.1",
         "@types/react-router-dom": "5.3.3",
         "@types/uuid": "8.3.1",
         "chalk": "4.1.2",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import { App } from "app";
 import reportWebVitals from "reportWebVitals";
 import { QueryClient, QueryClientProvider } from "react-query";
@@ -12,6 +12,11 @@ import { registerConsoleErrorToasts } from "utils/register-console-error-toasts"
 registerIndexStyleMutation();
 registerConsoleErrorToasts();
 
+// If you want to start measuring performance in your app, pass a function
+// to log results (for example: reportWebVitals(console.log))
+// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
+reportWebVitals();
+
 const queryClient = new QueryClient({
     defaultOptions: {
         queries: {
@@ -19,19 +24,14 @@ const queryClient = new QueryClient({
         },
     },
 });
+const root = createRoot(document.getElementById("root")!);
 
-ReactDOM.render(
+root.render(
     <React.StrictMode>
         <QueryClientProvider client={queryClient}>
             <ThemeProvider value={theme}>
                 <App />
             </ThemeProvider>
         </QueryClientProvider>
-    </React.StrictMode>,
-    document.getElementById("root")
+    </React.StrictMode>
 );
-
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();


### PR DESCRIPTION
Gets rid of the console error from React v18's deprecation of `ReactDOM.render` in favor of the new `createRoot` function.