### PR TITLE
Add Table of Contents to documentation pages

### DIFF
--- a/src/components/layouts/help-layout.tsx
+++ b/src/components/layouts/help-layout.tsx
@@ -52,7 +52,7 @@ const HelpLayout: React.FC<HelpLayoutProps> = (props: HelpLayoutProps) => {
                         </Tab>
                     ))}
                 </TabNavigation>
-                <Pane margin={majorScale(2)}>
+                <Pane margin={majorScale(2)} maxWidth={majorScale(90)}>
                     <Outlet />
                 </Pane>
             </Pane>

--- a/src/components/sidebar/help-dialog/help-dialog.tsx
+++ b/src/components/sidebar/help-dialog/help-dialog.tsx
@@ -10,6 +10,7 @@ import {
     MaximizeIcon,
     majorScale,
     ShareIcon,
+    Pane,
 } from "evergreen-ui";
 import { Markdown, MarkdownComponentMap } from "components/markdown";
 import { Flex } from "components/flex";
@@ -95,11 +96,16 @@ const HelpDialog: React.FC<HelpDialogProps> = (props: HelpDialogProps) => {
             width={isFullscreen ? "100%" : undefined}>
             {isLoading && <Spinner />}
             {!isLoading && (
-                <Markdown
-                    components={getComponentMap(selectedTab, setSelectedTab)}
-                    transformLinkUri={transformLinkUri(selectedTab)}>
-                    {content}
-                </Markdown>
+                <Pane maxWidth={isFullscreen ? majorScale(90) : undefined}>
+                    <Markdown
+                        components={getComponentMap(
+                            selectedTab,
+                            setSelectedTab
+                        )}
+                        transformLinkUri={transformLinkUri(selectedTab)}>
+                        {content}
+                    </Markdown>
+                </Pane>
             )}
         </Dialog>
     );

--- a/src/docs/how-to.md
+++ b/src/docs/how-to.md
@@ -2,6 +2,27 @@
 
 This section of the guide details individual features and functionality of the app. If you find the information is lacking or inaccurate, or you'd like to propose a new section, [please open up an issue](https://github.com/brandongregoryscott/beets/issues/new) or [shoot me an email](mailto:contact@brandonscott.me). I'll do my best to respond and add documentation or assist where possible!
 
+## Table of Contents
+
+-   [Workstation](#workstation)
+    -   [Export Project](#export-project)
+    -   [Export Dialog](#export-dialog)
+-   [File](#file)
+    -   [Renaming a File](#renaming-a-file)
+-   [Track](#track)
+    -   [Creating a Track](#creating-a-track)
+    -   [Naming a Track](#naming-a-track)
+    -   [Moving a Track](#moving-a-track)
+-   [Track Section](#track-section)
+    -   [Creating a Track Section](#creating-a-track-section)
+    -   [Moving a Track Section](#moving-a-track-section)
+    -   [Duplicating a Track Section](#duplicating-a-track-section)
+-   [Instrument](#instrument)
+    -   [Creating an Instrument](#creating-an-instrument)
+-   [Sequencer](#sequencer)
+    -   [Adding Steps](#adding-steps)
+    -   [Removing Steps](#removing-steps)
+
 ## Workstation
 
 ### Export Project
@@ -93,11 +114,18 @@ For additional information, see [Overview - Sequencer](./overview#sequener)
 
 ### Adding Steps
 
-1. To add steps, first select one or more samples from the dropdown menu.
-   ![Select samples in Sequencer Dialog](../../public/assets/SequencerSelectSamples.png)
-1. Once at least one sample is selected, click on a tile. Up to 4 samples can be assigned to one tile.
-   ![Assign samples in Sequencer Dialog](../../public/assets/SequencerSelectAssignSamples.gif)
-    - If a sample has already been assigned to a tile, it will not be readded. However, any additional samples that are currently selected will be added to the tile when clicked.
-1. To remove a sample, click on its name within the tile. You do not need to have any samples selected, and having samples selected will not add them to the tile when removing a sample.
+To add steps, first select one or more samples from the dropdown menu.
 
-    ![Remove samples in Sequencer Dialog](../../public/assets/SequencerRemoveSamples.gif)
+![Select samples in Sequencer Dialog](../../public/assets/SequencerSelectSamples.png)
+
+Once at least one sample is selected, click on a tile. Up to 4 samples can be assigned to one tile.
+
+![Assign samples in Sequencer Dialog](../../public/assets/SequencerSelectAssignSamples.gif)
+
+> If a sample has already been assigned to a tile, it will not be readded. However, any additional samples that are currently selected will be added to the tile when clicked.
+
+### Removing Steps
+
+To remove a sample, click on its name within the tile. You do not need to have any samples selected, and having samples selected will not add them to the tile when removing a sample.
+
+![Remove samples in Sequencer Dialog](../../public/assets/SequencerRemoveSamples.gif)

--- a/src/docs/overview.md
+++ b/src/docs/overview.md
@@ -2,23 +2,37 @@
 
 This guide will serve as high-level documentation for the various different pages, features, and domain terms in the application. If you find the information is lacking or inaccurate, or you'd like to propose a new section, [please open up an issue](https://github.com/brandongregoryscott/beets/issues/new) or [shoot me an email](mailto:contact@brandonscott.me). I'll do my best to respond and add documentation or assist where possible!
 
-### Workstation page
+## Table of Contents
+
+-   [Workstation page](#workstation-page)
+-   [Workstation](#workstation)
+-   [Project](#project)
+    -   [Track](#track)
+        -   [Piano Roll](#piano-roll)
+        -   [Sequencer](#sequencer)
+    -   [Track Section](#track-section)
+    -   [Track Section Step](#track-section-step)
+-   [Library](#library)
+    -   [File](#file)
+    -   [Instrument](#instrument)
+-   [Terms and Controls](#terms-and-controls)
+    -   [BPM](#bpm)
+    -   [Swing](#swing)
+    -   [Volume](#volume)
+    -   [Mute](#mute)
+    -   [Solo](#solo)
+
+## Workstation page
 
 -   Refers to the page on initial site load. This page holds audio controls and UI components for building out your project.
 
 ![Workstation page](../../public/assets/WorkstationPage.png)
 
-### Workstation
+## Workstation
 
 -   Data structure that contains persisted entities that make up a song: a [Project](#project), [Tracks](#track), [Track Sections](#track-section), and [Track Section Steps](#track-section-step). A Workstation is not persisted, but acts as a 1:1 container to a [Project](#project)
 
-### Library
-
--   Refers to the pages of the site for [File](#file) and [Instrument](#instrument) management. It can be accessed via the music note icon on the sidebar.
-
-![Library page](../../public/assets/Library.png)
-
-### Project
+## Project
 
 -   Container for parts of a musical composition. Has a name, [BPM](#bpm), [swing](#swing) and global [volume](#volume) values.
 -   Projects are private and only available for registered users.
@@ -35,6 +49,22 @@ This guide will serve as high-level documentation for the various different page
 
 ![Track component](../../public/assets/Track.png)
 
+#### Piano Roll
+
+-   Dialog that can be used to program in [Track Section Steps](#track-section-step) for an [Instrument](#instrument) type [Track's](#track) [Track Section](#track-section). It can be opened by hovering over a [Track Section](#track-section) and clicking the middle button:
+
+    ![Open Piano Roll Dialog](../../public/assets/OpenPianoRoll.png)
+
+    ![Piano Roll Dialog](../../public/assets/PianoRoll.png)
+
+#### Sequencer
+
+-   Dialog that can be used to program in [Track Section Steps](#track-section-step) for a given [Track Section](#track-section). It can be opened by hovering over a [Track Section](#track-section) and clicking the middle button:
+
+    ![Open Sequencer Dialog](../../public/assets/OpenSequencer.png)
+
+    ![Sequencer Dialog](../../public/assets/Sequencer.png)
+
 ### Track Section
 
 -   Collection of steps or notes of audio. Depending on the [Track](#track) type, these steps are added via the [Piano Roll](#piano-roll) or [Sequencer](#sequencer) dialogs.
@@ -47,6 +77,12 @@ This guide will serve as high-level documentation for the various different page
 
 ![Track Section Step components](../../public/assets/TrackSectionStep.png)
 
+## Library
+
+-   Refers to the pages of the site for [File](#file) and [Instrument](#instrument) management. It can be accessed via the music note icon on the sidebar.
+
+![Library page](../../public/assets/Library.png)
+
 ### File
 
 -   An uploaded music sample.
@@ -58,21 +94,7 @@ This guide will serve as high-level documentation for the various different page
 -   A persisted configuration for a sampled instrument. This allows you to set the root note, its duration, the release time, and curve of the sample.
 -   Samples that are configured as instruments can be pitched up or down in the [Piano Roll](#piano-roll) component, whereas standard [Sequencer](#sequencer) [Tracks](#track) cannot be.
 
-### Piano Roll
-
--   Dialog that can be used to program in [Track Section Steps](#track-section-step) for an [Instrument](#instrument) type [Track's](#track) [Track Section](#track-section). It can be opened by hovering over a [Track Section](#track-section) and clicking the middle button:
-
-    ![Open Piano Roll Dialog](../../public/assets/OpenPianoRoll.png)
-
-    ![Piano Roll Dialog](../../public/assets/PianoRoll.png)
-
-### Sequencer
-
--   Dialog that can be used to program in [Track Section Steps](#track-section-step) for a given [Track Section](#track-section). It can be opened by hovering over a [Track Section](#track-section) and clicking the middle button:
-
-    ![Open Sequencer Dialog](../../public/assets/OpenSequencer.png)
-
-    ![Sequencer Dialog](../../public/assets/Sequencer.png)
+## Terms and Controls
 
 ### BPM
 


### PR DESCRIPTION
Resolves #164

- Adds a `Table of Contents` section to both of the documentation pages
    - Some of the Overview documentation has been reordered to better fit the project hierarchy
- Adds a `maxWidth` style to both the fullscreen `HelpDialog` and the full page help routes via `HelpLayout`

Standard dialog:
![image](https://user-images.githubusercontent.com/11774799/163738332-fd7f583c-82f1-494b-bcf2-93c2c7d6b94c.png)

Fullscreen dialog:
![image](https://user-images.githubusercontent.com/11774799/163738289-49fe97fb-ea1a-40a7-a434-f57a15061569.png)

Overview page:
![image](https://user-images.githubusercontent.com/11774799/163738314-666be7c2-3d4e-453c-a92f-cb421f978255.png)
