### PR TITLE
Show step current step for column PianoRoll component

### DIFF
--- a/src/components/instruments/instrument-settings.tsx
+++ b/src/components/instruments/instrument-settings.tsx
@@ -21,7 +21,6 @@ import { useCreateOrUpdateInstrument } from "generated/hooks/domain/instruments/
 import { useDeleteInstrument } from "generated/hooks/domain/instruments/use-delete-instrument";
 import { isNilOrEmpty } from "utils/core-utils";
 import { useNumberInput } from "utils/hooks/use-number-input";
-import { MidiNoteUtils } from "utils/midi-note-utils";
 import { useInput } from "utils/hooks/use-input";
 import { Instrument } from "generated/interfaces/instrument";
 import { DialogFooter } from "components/dialog-footer";
@@ -31,6 +30,7 @@ import { TrackSectionRecord } from "models/track-section-record";
 import { TrackSectionStepRecord } from "models/track-section-step-record";
 import { List } from "immutable";
 import { useToneAudio } from "utils/hooks/use-tone-audio";
+import { defaultNote } from "constants/midi-notes";
 
 interface InstrumentSettingsProps {
     instrument?: InstrumentRecord;
@@ -122,7 +122,7 @@ const InstrumentSettings: React.FC<InstrumentSettingsProps> = (
         initialInstrument?.curve ?? InstrumentCurve.Exponential
     );
     const [rootNote, setRootNote] = useState<MidiNote>(
-        (initialInstrument?.root_note as MidiNote) ?? MidiNoteUtils.defaultNote
+        (initialInstrument?.root_note as MidiNote) ?? defaultNote
     );
     const { value: isAttemptingDelete, setTrue: handleDeleteClick } =
         useBoolean();

--- a/src/components/piano-roll/piano-key.tsx
+++ b/src/components/piano-roll/piano-key.tsx
@@ -1,15 +1,17 @@
 import { majorScale, Text, Pane } from "evergreen-ui";
-import { memo } from "react";
+import { isNumber } from "lodash";
 import { MidiNote } from "types/midi-note";
-import { MidiNoteUtils } from "utils/midi-note-utils";
+import { isMidiNote, isSharp } from "utils/midi-note-utils";
 
 interface PianoKeyProps {
-    note: MidiNote;
+    noteOrIndex?: MidiNote | number;
 }
 
 const PianoKey: React.FC<PianoKeyProps> = (props: PianoKeyProps) => {
-    const { note } = props;
-    const isBlackKey = MidiNoteUtils.isSharp(note);
+    const { noteOrIndex } = props;
+    const isSharpNote = isMidiNote(noteOrIndex) && isSharp(noteOrIndex);
+    const is4thBeat = isNumber(noteOrIndex) && noteOrIndex % 4 === 0;
+    const isBlackKey = isSharpNote || is4thBeat;
     const background = isBlackKey ? "black" : "white";
     const textColor = isBlackKey ? "white" : "black";
     const height = majorScale(4);
@@ -28,12 +30,10 @@ const PianoKey: React.FC<PianoKeyProps> = (props: PianoKeyProps) => {
             minWidth={width}
             width={width}>
             <Text color={textColor} cursor="default" size={300}>
-                {note}
+                {noteOrIndex}
             </Text>
         </Pane>
     );
 };
 
-const MemoizedPianoKey = memo(PianoKey);
-
-export { MemoizedPianoKey as PianoKey };
+export { PianoKey };

--- a/src/components/piano-roll/piano-roll-dialog.tsx
+++ b/src/components/piano-roll/piano-roll-dialog.tsx
@@ -7,6 +7,7 @@ import { TrackSectionStepRecord } from "models/track-section-step-record";
 import { useCallback, useState } from "react";
 import { InstrumentRecord } from "models/instrument-record";
 import { TrackRecord } from "models/track-record";
+import { useBoolean } from "utils/hooks/use-boolean";
 
 interface PianoRollDialogProps extends Pick<DialogProps, "onCloseComplete"> {
     file?: FileRecord;
@@ -31,6 +32,7 @@ const PianoRollDialog: React.FC<PianoRollDialogProps> = (
         trackSectionSteps: initialValue,
         trackSection,
     } = props;
+    const { value: isFullscreen, toggle: handleFullscreenClick } = useBoolean();
     const [trackSectionSteps, setTrackSectionSteps] =
         useState<List<TrackSectionStepRecord>>(initialValue);
     const [stepCount, setStepCount] = useState<number>(trackSection.step_count);
@@ -53,11 +55,14 @@ const PianoRollDialog: React.FC<PianoRollDialogProps> = (
 
     return (
         <Dialog
+            allowFullscreen={true}
             isShown={true}
             onCloseComplete={onCloseComplete}
             onConfirm={handleConfirm}
+            onFullscreenClick={handleFullscreenClick}
             title="Piano Roll">
             <PianoRoll
+                centerControls={isFullscreen}
                 file={file}
                 instrument={instrument}
                 onChange={setTrackSectionSteps}

--- a/src/components/piano-roll/piano-roll-row.tsx
+++ b/src/components/piano-roll/piano-roll-row.tsx
@@ -1,0 +1,22 @@
+import { Flex } from "components/flex";
+import { PropsWithChildren } from "react";
+import { useTheme } from "utils/hooks/use-theme";
+
+interface PianoRollRowProps {}
+
+const PianoRollRow: React.FC<PropsWithChildren<PianoRollRowProps>> = (
+    props: PropsWithChildren<PianoRollRowProps>
+) => {
+    const { children } = props;
+    const { colors } = useTheme();
+    return (
+        <Flex.Row
+            backgroundColor={colors.gray300}
+            flexGrow={1}
+            width="min-content">
+            {children}
+        </Flex.Row>
+    );
+};
+
+export { PianoRollRow };

--- a/src/components/piano-roll/piano-roll.tsx
+++ b/src/components/piano-roll/piano-roll.tsx
@@ -23,6 +23,7 @@ import { toDataAttributes } from "utils/data-attribute-utils";
 import { Flex } from "components/flex";
 
 interface PianoRollProps {
+    centerControls?: boolean;
     file?: FileRecord;
     instrument?: InstrumentRecord;
     onChange: (value: List<TrackSectionStepRecord>) => void;
@@ -41,6 +42,7 @@ const PianoRoll: React.FC<PianoRollProps> = (props: PianoRollProps) => {
     const {
         instrument,
         file,
+        centerControls,
         onChange,
         onStepCountChange,
         stepCount,
@@ -74,7 +76,9 @@ const PianoRoll: React.FC<PianoRollProps> = (props: PianoRollProps) => {
 
     return (
         <Pane {...toDataAttributes({ stepCount })}>
-            <Pane marginBottom={majorScale(1)}>
+            <Flex.Row
+                justifyContent={centerControls ? "center" : undefined}
+                marginBottom={majorScale(1)}>
                 <PlayButton
                     isLoading={isLoading}
                     isPlaying={isPlaying}
@@ -97,7 +101,7 @@ const PianoRoll: React.FC<PianoRollProps> = (props: PianoRollProps) => {
                     onChange={onStepCountChange}
                     stepCount={stepCount}
                 />
-            </Pane>
+            </Flex.Row>
             <Flex.Column flexGrow={1} width="100%">
                 <PianoSteps
                     file={file}

--- a/src/components/piano-roll/piano-roll.tsx
+++ b/src/components/piano-roll/piano-roll.tsx
@@ -14,13 +14,13 @@ import { TrackSectionStepRecord } from "models/track-section-step-record";
 import React, { useCallback, useState } from "react";
 import { useBoolean } from "utils/hooks/use-boolean";
 import { PlayButton } from "components/workstation/play-button";
-import { MidiNotes } from "constants/midi-notes";
+import { defaultNote, MidiNotes } from "constants/midi-notes";
 import { InstrumentRecord } from "models/instrument-record";
-import { MidiNoteUtils } from "utils/midi-note-utils";
 import { MidiNote } from "types/midi-note";
 import { useToneAudio } from "utils/hooks/use-tone-audio";
 import { TrackRecord } from "models/track-record";
 import { toDataAttributes } from "utils/data-attribute-utils";
+import { Flex } from "components/flex";
 
 interface PianoRollProps {
     file?: FileRecord;
@@ -34,7 +34,7 @@ interface PianoRollProps {
 }
 
 const buttonMarginRight = majorScale(1);
-const defaultNoteIndex = MidiNotes.indexOf(MidiNoteUtils.defaultNote);
+const defaultNoteIndex = MidiNotes.indexOf(defaultNote);
 const indexRange = 12; // Chromatic scale
 
 const PianoRoll: React.FC<PianoRollProps> = (props: PianoRollProps) => {
@@ -98,11 +98,7 @@ const PianoRoll: React.FC<PianoRollProps> = (props: PianoRollProps) => {
                     stepCount={stepCount}
                 />
             </Pane>
-            <Pane
-                display="flex"
-                flexDirection="column"
-                flexGrow={1}
-                width="100%">
+            <Flex.Column flexGrow={1} width="100%">
                 <PianoSteps
                     file={file}
                     indexRange={indexRange}
@@ -112,7 +108,7 @@ const PianoRoll: React.FC<PianoRollProps> = (props: PianoRollProps) => {
                     trackSectionSteps={trackSectionSteps}
                     viewableIndex={viewableIndex}
                 />
-            </Pane>
+            </Flex.Column>
         </Pane>
     );
 };

--- a/src/components/piano-roll/piano-step.tsx
+++ b/src/components/piano-roll/piano-step.tsx
@@ -1,4 +1,5 @@
-import { majorScale, Pane } from "evergreen-ui";
+import { Flex } from "components/flex";
+import { majorScale } from "evergreen-ui";
 import { useCallback } from "react";
 import { MidiNote } from "types/midi-note";
 import { useTheme } from "utils/hooks/use-theme";
@@ -21,13 +22,12 @@ const PianoStep: React.FC<PianoStepProps> = (props: PianoStepProps) => {
     );
 
     return (
-        <Pane
+        <Flex.Row
             alignItems="center"
             background={isSelected ? colors.gray700 : colors.gray300}
             borderWidth={1}
             cursor="pointer"
             data-index={index}
-            display="flex"
             flexGrow={1}
             height={height}
             hoverElevation={1}

--- a/src/components/piano-roll/piano-steps.tsx
+++ b/src/components/piano-roll/piano-steps.tsx
@@ -1,15 +1,15 @@
+import { Flex } from "components/flex";
 import { PianoKey } from "components/piano-roll/piano-key";
+import { PianoRollRow } from "components/piano-roll/piano-roll-row";
 import { PianoStep } from "components/piano-roll/piano-step";
 import { MidiNotes } from "constants/midi-notes";
-import { Pane } from "evergreen-ui";
 import { List } from "immutable";
-import _ from "lodash";
+import { range } from "lodash";
 import { FileRecord } from "models/file-record";
 import { TrackSectionRecord } from "models/track-section-record";
 import { TrackSectionStepRecord } from "models/track-section-step-record";
 import React, { useCallback, useMemo } from "react";
 import { MidiNote } from "types/midi-note";
-import { useTheme } from "utils/hooks/use-theme";
 import { isSelected } from "utils/track-section-step-utils";
 
 interface PianoStepsProps {
@@ -33,7 +33,6 @@ const PianoSteps: React.FC<PianoStepsProps> = (props: PianoStepsProps) => {
         trackSectionSteps,
     } = props;
 
-    const { colors } = useTheme();
     const handleClick = useCallback(
         (index: number, note: MidiNote) => {
             if (isSelected(trackSectionSteps, index, note)) {
@@ -71,18 +70,20 @@ const PianoSteps: React.FC<PianoStepsProps> = (props: PianoStepsProps) => {
         [indexRange, viewableIndex]
     );
 
-    const innerContent = useMemo(
-        () =>
-            notes.map((note) => (
-                <Pane
-                    backgroundColor={colors.gray300}
-                    display="flex"
-                    flexDirection="row"
-                    flexGrow={1}
-                    key={`piano-steps-pane-${note}`}
-                    width="min-content">
-                    <PianoKey key={`${PianoKey.name}-${note}`} note={note} />
-                    {_.range(0, stepCount).map((index: number) => (
+    return (
+        <Flex.Column justifyContent="center" marginX="auto">
+            <PianoRollRow>
+                {range(0, stepCount + 1).map((index: number) => (
+                    <PianoKey
+                        key={index}
+                        noteOrIndex={index === 0 ? undefined : index}
+                    />
+                ))}
+            </PianoRollRow>
+            {notes.map((note) => (
+                <PianoRollRow key={`${PianoRollRow.name}${note}`}>
+                    <PianoKey noteOrIndex={note} />
+                    {range(0, stepCount).map((index: number) => (
                         <PianoStep
                             index={index}
                             isSelected={isSelected(
@@ -90,23 +91,14 @@ const PianoSteps: React.FC<PianoStepsProps> = (props: PianoStepsProps) => {
                                 index,
                                 note
                             )}
-                            key={`${PianoStep.name}-${note}-${index}`}
+                            key={`${PianoStep.name}${index}${note}`}
                             note={note}
                             onClick={handleClick}
                         />
                     ))}
-                </Pane>
-            )),
-        [colors.gray300, handleClick, notes, stepCount, trackSectionSteps]
-    );
-    return (
-        <Pane
-            display="flex"
-            flexDirection="column"
-            justifyContent="center"
-            marginX="auto">
-            {innerContent}
-        </Pane>
+                </PianoRollRow>
+            ))}
+        </Flex.Column>
     );
 };
 

--- a/src/components/sidebar/help-dialog/help-dialog.tsx
+++ b/src/components/sidebar/help-dialog/help-dialog.tsx
@@ -5,9 +5,6 @@ import {
     Tablist,
     Tab,
     IconButton,
-    CrossIcon,
-    MinimizeIcon,
-    MaximizeIcon,
     majorScale,
     ShareIcon,
     Pane,
@@ -15,7 +12,6 @@ import {
     CircleArrowUpIcon,
 } from "evergreen-ui";
 import { Markdown, MarkdownComponentMap } from "components/markdown";
-import { Flex } from "components/flex";
 import { HelpResource } from "enums/help-resource";
 import { useHelpDocs } from "utils/hooks/use-help-docs";
 import { useBoolean } from "utils/hooks/use-boolean";
@@ -55,18 +51,11 @@ const HelpDialog: React.FC<HelpDialogProps> = (props: HelpDialogProps) => {
 
     return (
         <Dialog
-            containerProps={
-                isFullscreen
-                    ? {
-                          marginY: majorScale(2),
-                          maxHeight: `calc(100% - ${majorScale(4)}px)`,
-                      }
-                    : undefined
-            }
+            allowFullscreen={true}
             contentContainerProps={{ ref: contentContainerRef }}
             hasFooter={false}
-            header={({ close }) => (
-                <Flex.Row alignItems="center" width="100%">
+            header={
+                <React.Fragment>
                     <Tablist>
                         {HelpResourceTabs.map((tab) => (
                             <Tab
@@ -85,23 +74,11 @@ const HelpDialog: React.FC<HelpDialogProps> = (props: HelpDialogProps) => {
                         target="_blank"
                         to={sharePath}
                     />
-                    <IconButton
-                        appearance="minimal"
-                        icon={isFullscreen ? MinimizeIcon : MaximizeIcon}
-                        marginLeft={majorScale(1)}
-                        onClick={handleFullscreenClick}
-                    />
-                    <IconButton
-                        appearance="minimal"
-                        icon={CrossIcon}
-                        marginLeft={majorScale(1)}
-                        onClick={close}
-                    />
-                </Flex.Row>
-            )}
+                </React.Fragment>
+            }
             isShown={true}
             onCloseComplete={onCloseComplete}
-            width={isFullscreen ? "100%" : undefined}>
+            onFullscreenClick={handleFullscreenClick}>
             {isLoading && <Spinner />}
             {!isLoading && (
                 <Pane maxWidth={isFullscreen ? majorScale(90) : undefined}>

--- a/src/constants/midi-notes.ts
+++ b/src/constants/midi-notes.ts
@@ -131,4 +131,6 @@ const MidiNotes: MidiNote[] = [
     "G8",
 ];
 
-export { MidiNotes };
+const defaultNote = "C4";
+
+export { defaultNote, MidiNotes };

--- a/src/models/workstation-state-record.ts
+++ b/src/models/workstation-state-record.ts
@@ -1,3 +1,4 @@
+import { defaultNote } from "constants/midi-notes";
 import { DemoInstrument } from "enums/demo-instrument";
 import { List, Record } from "immutable";
 import { WorkstationState } from "interfaces/workstation-state";
@@ -19,7 +20,6 @@ import {
 } from "utils/collection-utils";
 import { makeDefaultValues } from "utils/core-utils";
 import { findKick, findHat, findOpenHat, findSnare } from "utils/file-utils";
-import { MidiNoteUtils } from "utils/midi-note-utils";
 import { getByTrack } from "utils/track-section-utils";
 
 interface WorkstationStateDiff {
@@ -91,7 +91,7 @@ class WorkstationStateRecord
             index: 0,
             file_id: wavyPad?.id,
             track_section_id: padTrackSection.id,
-            note: MidiNoteUtils.defaultNote,
+            note: defaultNote,
         });
 
         const kickSteps = [

--- a/src/utils/midi-note-utils.ts
+++ b/src/utils/midi-note-utils.ts
@@ -1,12 +1,15 @@
+import { isEmpty, isNumber } from "lodash";
 import { MidiNote } from "types/midi-note";
+import { MidiNotes } from "constants/midi-notes";
 
-const defaultNote: MidiNote = "C4";
+export const isMidiNote = (
+    maybeNote?: string | number
+): maybeNote is MidiNote => {
+    if (isEmpty(maybeNote) || isNumber(maybeNote)) {
+        return false;
+    }
 
-const MidiNoteUtils = {
-    defaultNote,
-    isSharp(note: MidiNote): boolean {
-        return note.includes("#");
-    },
+    return MidiNotes.some((midiNote) => midiNote === maybeNote);
 };
 
-export { MidiNoteUtils };
+export const isSharp = (note: MidiNote): boolean => note.includes("#");


### PR DESCRIPTION
Resolves #152

- Adds a new row above the `PianoRoll` component to display the current step number for the column.

![image](https://user-images.githubusercontent.com/11774799/164071579-01db1299-41b2-4e8a-9fd6-d2cd08001d5a.png)

- Additionally, the base `Dialog` component that we are wrapping from Evergreen now has logic to display a maximize/minimize button for rendering in fullscreen. This feature is not turned on by default and is controlled by the `allowFullscreen` prop. This ports over the functionality that previously only existed in the `HelpDialog`, and allows it to be used in the `PianoRollDialog` which might be useful to see the full grid!