### PR TITLE
Add Windows/Linux support for keyboard shortcuts

### DIFF
--- a/src/components/workstation/edit-tab.tsx
+++ b/src/components/workstation/edit-tab.tsx
@@ -12,6 +12,8 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { useClipboardState } from "utils/hooks/use-clipboard-state";
 import { useToneControls } from "utils/hooks/use-tone-controls";
 
+const shortcutKey = navigator.platform.includes("Mac") ? "⌘" : "Ctrl+";
+
 interface EditTabProps {}
 
 const EditTab: React.FC<EditTabProps> = (props: EditTabProps) => {
@@ -40,7 +42,7 @@ const EditTab: React.FC<EditTabProps> = (props: EditTabProps) => {
                                 closePopover,
                                 duplicateSelected
                             )}
-                            secondaryText={"⌘D" as any}>
+                            secondaryText={shortcutKey + "D" as any}>
                             Duplicate
                         </Menu.Item>
                         <Menu.Item

--- a/src/components/workstation/edit-tab.tsx
+++ b/src/components/workstation/edit-tab.tsx
@@ -26,7 +26,7 @@ const EditTab: React.FC<EditTabProps> = (props: EditTabProps) => {
         []
     );
 
-    useHotkeys("cmd+d", duplicateSelected, [isPlaying, selectedState]);
+    useHotkeys("cmd+d, ctrl+d", duplicateSelected, [isPlaying, selectedState]);
 
     return (
         <React.Fragment>

--- a/src/components/workstation/file-tab.tsx
+++ b/src/components/workstation/file-tab.tsx
@@ -16,6 +16,8 @@ import { isNotNilOrEmpty } from "utils/core-utils";
 import { useHotkeys } from "react-hotkeys-hook";
 import { ExportDialog } from "components/workstation/export-dialog";
 
+const shortcutKey = navigator.platform.includes("Mac") ? "⌘" : "Ctrl+";
+
 interface FileTabProps {}
 
 enum ConfirmationAction {
@@ -205,7 +207,7 @@ const FileTab: React.FC<FileTabProps> = (props: FileTabProps) => {
                         </Menu.Item>
                         <Menu.Item
                             onClick={handleSave(closePopover)}
-                            secondaryText={"⌘S" as any}>
+                            secondaryText={shortcutKey + "S" as any}>
                             Save
                         </Menu.Item>
                         <Menu.Item onClick={handleExportClick(closePopover)}>

--- a/src/components/workstation/file-tab.tsx
+++ b/src/components/workstation/file-tab.tsx
@@ -129,7 +129,7 @@ const FileTab: React.FC<FileTabProps> = (props: FileTabProps) => {
     );
 
     useHotkeys(
-        "cmd+s",
+        "cmd+s, ctrl+s",
         (event) => {
             event.preventDefault();
             handleSave()();


### PR DESCRIPTION
Adds support for non Mac systems to use the `Save File` and `Duplicate Selection` keyboard shortcuts.