### PR TITLE
Instrument page updates

### DIFF
--- a/src/components/confirmation-dialog.tsx
+++ b/src/components/confirmation-dialog.tsx
@@ -2,7 +2,7 @@ import { Alert, IntentTypes } from "evergreen-ui";
 import { Dialog, DialogProps } from "components/dialog";
 import React from "react";
 
-interface ConfirmationDialogProps extends DialogProps {
+interface ConfirmationDialogProps extends Omit<DialogProps, "onCancel"> {
     alertDescription: string;
     alertIntent?: IntentTypes;
     alertTitle?: string;
@@ -17,7 +17,6 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = (
         alertDescription,
         confirmLabel = "Confirm",
         isConfirmLoading,
-        isShown,
         onCloseComplete,
         onConfirm,
         title = "Are you sure?",
@@ -27,7 +26,6 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = (
         <Dialog
             confirmLabel={confirmLabel}
             isConfirmLoading={isConfirmLoading}
-            isShown={isShown}
             onCloseComplete={onCloseComplete}
             onConfirm={onConfirm}
             shouldCloseOnOverlayClick={false}

--- a/src/components/contextual-icon-button.tsx
+++ b/src/components/contextual-icon-button.tsx
@@ -23,6 +23,8 @@ interface ContextualIconButtonProps
     tooltipText: string;
 }
 
+type VisibilityState = "visible" | "hidden";
+
 const ContextualIconButton: React.FC<ContextualIconButtonProps> = (
     props: ContextualIconButtonProps
 ) => {
@@ -42,7 +44,7 @@ const ContextualIconButton: React.FC<ContextualIconButtonProps> = (
     const { draggableId } = useDraggable();
     const isCurrentElementDragging = draggableId != null && draggableId === id;
     const isOtherElementDragging = draggableId != null && draggableId !== id;
-    const visibility: DocumentVisibilityState = isCurrentElementDragging
+    const visibility: VisibilityState = isCurrentElementDragging
         ? "visible"
         : "hidden";
 

--- a/src/components/dialog-footer.tsx
+++ b/src/components/dialog-footer.tsx
@@ -56,4 +56,5 @@ const DialogFooter: React.FC<DialogFooterProps> = (
     );
 };
 
+export type { DialogFooterProps };
 export { DialogFooter };

--- a/src/components/dialog.tsx
+++ b/src/components/dialog.tsx
@@ -14,7 +14,7 @@ import React, { useCallback } from "react";
 import { attachEventSource } from "utils/event-utils";
 import { useBoolean } from "utils/hooks/use-boolean";
 
-interface DialogProps extends EvergreenDialogProps {
+interface DialogProps extends Omit<EvergreenDialogProps, "isShown"> {
     allowFullscreen?: boolean;
     initialIsFullscreen?: boolean;
     onFullscreenClick?: () => void;
@@ -101,6 +101,7 @@ const Dialog: React.FC<DialogProps> = (props: DialogProps) => {
                       )
                     : undefined
             }
+            isShown={true}
             width={allowFullscreen && isFullscreen ? "100%" : width}>
             {children}
         </EvergreenDialog>

--- a/src/components/files/file-card.tsx
+++ b/src/components/files/file-card.tsx
@@ -106,7 +106,6 @@ const FileCard: React.FC<FileCardProps> = (props: FileCardProps) => {
             {isOpen && (
                 <FileSettingsDialog
                     file={file}
-                    isShown={isOpen}
                     onCloseComplete={handleCloseDialog}
                     storageProviderFile={storageProviderFile}
                 />

--- a/src/components/files/file-settings-dialog.tsx
+++ b/src/components/files/file-settings-dialog.tsx
@@ -7,8 +7,7 @@ import { Dialog, DialogProps } from "components/dialog";
 import { useInput } from "utils/hooks/use-input";
 import humanize from "humanize-plus";
 
-interface FileSettingsDialogProps
-    extends Pick<DialogProps, "isShown" | "onCloseComplete"> {
+interface FileSettingsDialogProps extends Pick<DialogProps, "onCloseComplete"> {
     file: FileRecord;
     storageProviderFile: StorageProviderFileRecord;
 }
@@ -18,7 +17,7 @@ const title = "Edit File";
 const FileSettingsDialog: React.FC<FileSettingsDialogProps> = (
     props: FileSettingsDialogProps
 ) => {
-    const { isShown, onCloseComplete, file } = props;
+    const { onCloseComplete, file } = props;
     const {
         value: name,
         onChange: handleNameChange,
@@ -40,7 +39,6 @@ const FileSettingsDialog: React.FC<FileSettingsDialogProps> = (
         <Dialog
             confirmLabel="Save"
             isConfirmLoading={isLoading}
-            isShown={isShown}
             onCloseComplete={onCloseComplete}
             onConfirm={handleSave}
             shouldCloseOnOverlayClick={false}

--- a/src/components/instruments/choose-or-create-instrument-dialog.tsx
+++ b/src/components/instruments/choose-or-create-instrument-dialog.tsx
@@ -7,7 +7,7 @@ import { useGlobalState } from "utils/hooks/use-global-state";
 import { InstrumentSettings } from "components/instruments/instrument-settings";
 
 interface ChooseOrCreateInstrumentDialogProps
-    extends Pick<DialogProps, "isShown" | "onCloseComplete"> {
+    extends Pick<DialogProps, "onCloseComplete"> {
     instrument?: InstrumentRecord;
     onSubmit?: (instrument: InstrumentRecord) => void;
     showTabs?: boolean;
@@ -25,7 +25,6 @@ const ChooseOrCreateInstrumentDialog: React.FC<
 > = (props: ChooseOrCreateInstrumentDialogProps) => {
     const {
         instrument: initialInstrument,
-        isShown,
         onCloseComplete,
         onSubmit,
         showTabs = true,
@@ -69,7 +68,6 @@ const ChooseOrCreateInstrumentDialog: React.FC<
                 selectedTab === DialogTab.ChooseInstrument &&
                 selectedInstrument == null
             }
-            isShown={isShown}
             onCloseComplete={onCloseComplete}
             onSubmit={handleSelectInstrumentSubmit}
             title="Instrument Settings">

--- a/src/components/instruments/choose-or-create-instrument-dialog.tsx
+++ b/src/components/instruments/choose-or-create-instrument-dialog.tsx
@@ -15,6 +15,7 @@ import { InstrumentSettings } from "components/instruments/instrument-settings";
 import { useListInstruments } from "utils/hooks/domain/instruments/use-list-instruments";
 import { useListFiles } from "utils/hooks/domain/files/use-list-files";
 import { useTheme } from "utils/hooks/use-theme";
+import { generateId } from "utils/id-utils";
 
 interface ChooseOrCreateInstrumentDialogProps
     extends Pick<DialogProps, "onCloseComplete"> {
@@ -34,7 +35,9 @@ const ChooseOrCreateInstrumentDialog: React.FC<
     ChooseOrCreateInstrumentDialogProps
 > = (props: ChooseOrCreateInstrumentDialogProps) => {
     const {
-        instrument: initialInstrument,
+        instrument: initialInstrument = new InstrumentRecord().merge({
+            id: generateId(),
+        }),
         onCloseComplete,
         onSubmit,
         showTabs = true,

--- a/src/components/instruments/choose-or-create-instrument-dialog.tsx
+++ b/src/components/instruments/choose-or-create-instrument-dialog.tsx
@@ -1,10 +1,20 @@
 import { FormDialog } from "components/forms/form-dialog";
 import { InstrumentsTable } from "components/instruments/instruments-table";
-import { DialogProps, majorScale, Tab, Tablist } from "evergreen-ui";
+import {
+    DialogProps,
+    EmptyState,
+    majorScale,
+    StepChartIcon,
+    Tab,
+    Tablist,
+} from "evergreen-ui";
 import { InstrumentRecord } from "models/instrument-record";
 import React, { useCallback, useState } from "react";
 import { useGlobalState } from "utils/hooks/use-global-state";
 import { InstrumentSettings } from "components/instruments/instrument-settings";
+import { useListInstruments } from "utils/hooks/domain/instruments/use-list-instruments";
+import { useListFiles } from "utils/hooks/domain/files/use-list-files";
+import { useTheme } from "utils/hooks/use-theme";
 
 interface ChooseOrCreateInstrumentDialogProps
     extends Pick<DialogProps, "onCloseComplete"> {
@@ -30,6 +40,10 @@ const ChooseOrCreateInstrumentDialog: React.FC<
         showTabs = true,
     } = props;
     const { globalState } = useGlobalState();
+    const { colors } = useTheme();
+    const { resultObject: files, isLoading: isLoadingFiles } = useListFiles();
+    const { resultObject: instruments, isLoading: isLoadingInstruments } =
+        useListInstruments({ files });
     const [selectedTab, setSelectedTab] = useState<DialogTab>(
         globalState.isAuthenticated()
             ? DialogTab.CreateInstrument
@@ -85,6 +99,17 @@ const ChooseOrCreateInstrumentDialog: React.FC<
             )}
             {selectedTab === DialogTab.ChooseInstrument && (
                 <InstrumentsTable
+                    emptyState={
+                        <EmptyState
+                            description="Save a new Instrument to begin"
+                            icon={<StepChartIcon color={colors.gray500} />}
+                            iconBgColor={colors.gray200}
+                            title="No Instruments Found"
+                        />
+                    }
+                    files={files}
+                    instruments={instruments}
+                    isLoading={isLoadingFiles || isLoadingInstruments}
                     isSelectable={true}
                     onSelect={setSelectedInstrument}
                     selected={selectedInstrument}

--- a/src/components/instruments/instrument-settings.tsx
+++ b/src/components/instruments/instrument-settings.tsx
@@ -23,7 +23,7 @@ import { isNilOrEmpty } from "utils/core-utils";
 import { useNumberInput } from "utils/hooks/use-number-input";
 import { useInput } from "utils/hooks/use-input";
 import { Instrument } from "generated/interfaces/instrument";
-import { DialogFooter } from "components/dialog-footer";
+import { DialogFooter, DialogFooterProps } from "components/dialog-footer";
 import { MidiNote } from "types/midi-note";
 import { TrackRecord } from "models/track-record";
 import { TrackSectionRecord } from "models/track-section-record";
@@ -32,9 +32,11 @@ import { List } from "immutable";
 import { useToneAudio } from "utils/hooks/use-tone-audio";
 import { defaultNote } from "constants/midi-notes";
 
-interface InstrumentSettingsProps {
+interface InstrumentSettingsProps
+    extends Pick<DialogFooterProps, "confirmLabel"> {
     instrument?: InstrumentRecord;
     onCancel?: () => void;
+    onChange?: (instrument: InstrumentRecord) => void;
     onCreateOrUpdate?: (instrument: InstrumentRecord) => void;
     onDelete?: () => void;
 }
@@ -46,8 +48,10 @@ const InstrumentSettings: React.FC<InstrumentSettingsProps> = (
     props: InstrumentSettingsProps
 ) => {
     const {
+        confirmLabel,
         instrument: initialInstrument,
         onCreateOrUpdate,
+        onChange,
         onCancel,
         onDelete,
     } = props;
@@ -133,7 +137,7 @@ const InstrumentSettings: React.FC<InstrumentSettingsProps> = (
             duration,
             name,
             release,
-            file_id: file?.id,
+            file_id: file?.id ?? initialInstrument?.file_id,
             root_note: rootNote,
         };
 
@@ -143,6 +147,10 @@ const InstrumentSettings: React.FC<InstrumentSettingsProps> = (
 
         return instrument;
     }, [curve, duration, file?.id, initialInstrument, name, release, rootNote]);
+
+    useEffect(() => {
+        onChange?.(instrument);
+    }, [instrument, onChange]);
 
     const handleFileSelected = useCallback(
         (file: FileRecord) => {
@@ -292,7 +300,9 @@ const InstrumentSettings: React.FC<InstrumentSettingsProps> = (
                     </Button>
                 </SelectMenu>
             </FormField>
-            <FormField label="Sample" {...fileValidation}>
+            <FormField
+                label="Sample"
+                validationMessage={fileValidation?.validationMessage}>
                 <FileSelectMenu
                     hasTitle={false}
                     onDeselect={handleFileSelected}
@@ -334,6 +344,7 @@ const InstrumentSettings: React.FC<InstrumentSettingsProps> = (
             )}
             <ErrorAlert error={error} />
             <DialogFooter
+                confirmLabel={confirmLabel}
                 isConfirmDisabled={isAttemptingDelete}
                 isConfirmLoading={isLoading}
                 onCancel={onCancel}

--- a/src/components/instruments/instruments-table.tsx
+++ b/src/components/instruments/instruments-table.tsx
@@ -1,19 +1,16 @@
-import {
-    Table,
-    Spinner,
-    EmptyState,
-    TableRowProps,
-    StepChartIcon,
-} from "evergreen-ui";
-import { useListInstruments } from "utils/hooks/domain/instruments/use-list-instruments";
+import { Table, Spinner, TableRowProps } from "evergreen-ui";
 import { InstrumentRecord } from "models/instrument-record";
 import { hasValues } from "utils/collection-utils";
 import { formatUpdatedOn } from "utils/date-utils";
 import { getFileById } from "utils/file-utils";
-import { useListFiles } from "utils/hooks/domain/files/use-list-files";
-import { useTheme } from "utils/hooks/use-theme";
+import { List } from "immutable";
+import { FileRecord } from "models/file-record";
 
 interface InstrumentsTableProps extends Pick<TableRowProps, "isSelectable"> {
+    emptyState?: React.ReactNode;
+    files?: List<FileRecord> | FileRecord[];
+    instruments?: List<InstrumentRecord> | InstrumentRecord[];
+    isLoading?: boolean;
     onDeselect?: (instrument: InstrumentRecord) => void;
     onSelect?: (instrument: InstrumentRecord) => void;
     selected?: InstrumentRecord;
@@ -22,13 +19,17 @@ interface InstrumentsTableProps extends Pick<TableRowProps, "isSelectable"> {
 const InstrumentsTable: React.FC<InstrumentsTableProps> = (
     props: InstrumentsTableProps
 ) => {
-    const { colors } = useTheme();
-    const { isSelectable, onDeselect, onSelect, selected } = props;
-    const { resultObject: files, isLoading: isLoadingFiles } = useListFiles();
-    const { resultObject: instruments, isLoading: isLoadingInstruments } =
-        useListInstruments({ files });
+    const {
+        isSelectable,
+        onDeselect,
+        onSelect,
+        selected,
+        isLoading,
+        emptyState,
+        instruments,
+        files,
+    } = props;
 
-    const isLoading = isLoadingFiles || isLoadingInstruments;
     const hasInstruments = !isLoading && hasValues(instruments);
 
     return (
@@ -61,14 +62,7 @@ const InstrumentsTable: React.FC<InstrumentsTableProps> = (
                             </Table.TextCell>
                         </Table.Row>
                     ))}
-                {!hasInstruments && !isLoading && (
-                    <EmptyState
-                        description="Save a new Instrument to begin"
-                        icon={<StepChartIcon color={colors.gray500} />}
-                        iconBgColor={colors.gray200}
-                        title="No Instruments Found"
-                    />
-                )}
+                {!hasInstruments && !isLoading && emptyState}
             </Table.Body>
         </Table>
     );

--- a/src/components/instruments/instruments-table.tsx
+++ b/src/components/instruments/instruments-table.tsx
@@ -2,18 +2,19 @@ import {
     Table,
     Spinner,
     EmptyState,
-    StyleIcon,
     TableRowProps,
+    StepChartIcon,
 } from "evergreen-ui";
 import { useListInstruments } from "utils/hooks/domain/instruments/use-list-instruments";
 import { InstrumentRecord } from "models/instrument-record";
-import { theme } from "theme";
 import { hasValues } from "utils/collection-utils";
 import { formatUpdatedOn } from "utils/date-utils";
 import { getFileById } from "utils/file-utils";
 import { useListFiles } from "utils/hooks/domain/files/use-list-files";
+import { useTheme } from "utils/hooks/use-theme";
 
 interface InstrumentsTableProps extends Pick<TableRowProps, "isSelectable"> {
+    onDeselect?: (instrument: InstrumentRecord) => void;
     onSelect?: (instrument: InstrumentRecord) => void;
     selected?: InstrumentRecord;
 }
@@ -21,7 +22,8 @@ interface InstrumentsTableProps extends Pick<TableRowProps, "isSelectable"> {
 const InstrumentsTable: React.FC<InstrumentsTableProps> = (
     props: InstrumentsTableProps
 ) => {
-    const { isSelectable, onSelect, selected } = props;
+    const { colors } = useTheme();
+    const { isSelectable, onDeselect, onSelect, selected } = props;
     const { resultObject: files, isLoading: isLoadingFiles } = useListFiles();
     const { resultObject: instruments, isLoading: isLoadingInstruments } =
         useListInstruments({ files });
@@ -37,13 +39,18 @@ const InstrumentsTable: React.FC<InstrumentsTableProps> = (
                 <Table.TextHeaderCell>Updated On</Table.TextHeaderCell>
             </Table.Head>
             <Table.Body>
-                {isLoading && <Spinner margin="auto" />}
+                {isLoading && (
+                    <Table.Row>
+                        <Spinner margin="auto" />
+                    </Table.Row>
+                )}
                 {hasInstruments &&
                     instruments?.map((instrument) => (
                         <Table.Row
                             isSelectable={isSelectable}
                             isSelected={instrument.equals(selected)}
                             key={instrument.id}
+                            onDeselect={() => onDeselect?.(instrument)}
                             onSelect={() => onSelect?.(instrument)}>
                             <Table.TextCell>{instrument.name}</Table.TextCell>
                             <Table.TextCell>
@@ -56,9 +63,9 @@ const InstrumentsTable: React.FC<InstrumentsTableProps> = (
                     ))}
                 {!hasInstruments && !isLoading && (
                     <EmptyState
-                        description="Save a new instrument to begin"
-                        icon={<StyleIcon color={theme.colors.gray800} />}
-                        iconBgColor={theme.colors.gray100}
+                        description="Save a new Instrument to begin"
+                        icon={<StepChartIcon color={colors.gray500} />}
+                        iconBgColor={colors.gray200}
                         title="No Instruments Found"
                     />
                 )}

--- a/src/components/pages/instruments-page.tsx
+++ b/src/components/pages/instruments-page.tsx
@@ -10,9 +10,12 @@ import {
     BanCircleIcon,
     StepChartIcon,
 } from "evergreen-ui";
+import { useListFiles } from "generated/hooks/domain/files/use-list-files";
+import { useListInstruments } from "generated/hooks/domain/instruments/use-list-instruments";
 import { RouteProps } from "interfaces/route-props";
 import { InstrumentRecord } from "models/instrument-record";
 import React, { useCallback, useMemo, useState } from "react";
+import { hasValues } from "utils/collection-utils";
 import { useDialog } from "utils/hooks/use-dialog";
 import { useGlobalState } from "utils/hooks/use-global-state";
 import { useTheme } from "utils/hooks/use-theme";
@@ -26,6 +29,10 @@ const InstrumentsPage: React.FC<InstrumentsPageProps> = (
 ) => {
     const { globalState } = useGlobalState();
     const { colors, intents } = useTheme();
+    const { resultObject: files, isLoading: isLoadingFiles } = useListFiles();
+    const { resultObject: instruments, isLoading: isLoadingInstruments } =
+        useListInstruments();
+
     const [stagedInstrument, setStagedInstrument] = useState<
         InstrumentRecord | undefined
     >();
@@ -111,12 +118,34 @@ const InstrumentsPage: React.FC<InstrumentsPageProps> = (
         resetInstrument();
     }, [resetInstrument]);
 
+    const isLoading = isLoadingFiles || isLoadingInstruments;
+    const hasInstruments = !isLoading && hasValues(instruments);
+
     return (
         <Pane marginRight={majorScale(2)} marginTop={majorScale(1)}>
             {globalState.isAuthenticated() && (
                 <Flex.Row>
                     <Pane width={majorScale(65)}>
                         <InstrumentsTable
+                            emptyState={
+                                <EmptyState
+                                    description="Create a new Instrument to begin"
+                                    icon={
+                                        <StepChartIcon color={colors.gray500} />
+                                    }
+                                    iconBgColor={colors.gray200}
+                                    primaryCta={
+                                        <EmptyState.PrimaryButton
+                                            onClick={handleCreate}>
+                                            Create Instrument
+                                        </EmptyState.PrimaryButton>
+                                    }
+                                    title="No Instruments Found"
+                                />
+                            }
+                            files={files}
+                            instruments={instruments}
+                            isLoading={isLoadingFiles || isLoadingInstruments}
                             isSelectable={true}
                             onSelect={handleSelect}
                             selected={initialInstrument}
@@ -137,7 +166,7 @@ const InstrumentsPage: React.FC<InstrumentsPageProps> = (
                                 onDelete={handleDelete}
                             />
                         )}
-                        {instrument == null && (
+                        {instrument == null && hasInstruments && (
                             <Pane marginRight={majorScale(2)}>
                                 <EmptyState
                                     background="dark"

--- a/src/components/pages/instruments-page.tsx
+++ b/src/components/pages/instruments-page.tsx
@@ -115,7 +115,7 @@ const InstrumentsPage: React.FC<InstrumentsPageProps> = (
         <Pane marginRight={majorScale(2)} marginTop={majorScale(1)}>
             {globalState.isAuthenticated() && (
                 <Flex.Row>
-                    <Pane maxWidth="40%" minWidth="40%">
+                    <Pane width={majorScale(65)}>
                         <InstrumentsTable
                             isSelectable={true}
                             onSelect={handleSelect}
@@ -124,21 +124,18 @@ const InstrumentsPage: React.FC<InstrumentsPageProps> = (
                     </Pane>
                     <Flex.Column
                         marginLeft={majorScale(2)}
-                        maxWidth="60%"
-                        minWidth="60%">
+                        width={majorScale(60)}>
                         {instrument != null && (
-                            <Pane maxWidth="75%">
-                                <InstrumentSettings
-                                    confirmLabel="Save"
-                                    instrument={instrument}
-                                    /** Explicitly setting key here to force a re-render when instrument is changed */
-                                    key={instrument.id}
-                                    onCancel={handleCancel}
-                                    onChange={handleChange}
-                                    onCreateOrUpdate={handleCreateOrUpdate}
-                                    onDelete={handleDelete}
-                                />
-                            </Pane>
+                            <InstrumentSettings
+                                confirmLabel="Save"
+                                instrument={instrument}
+                                /** Explicitly setting key here to force a re-render when instrument is changed */
+                                key={instrument.id}
+                                onCancel={handleCancel}
+                                onChange={handleChange}
+                                onCreateOrUpdate={handleCreateOrUpdate}
+                                onDelete={handleDelete}
+                            />
                         )}
                         {instrument == null && (
                             <Pane marginRight={majorScale(2)}>

--- a/src/components/pages/instruments-page.tsx
+++ b/src/components/pages/instruments-page.tsx
@@ -1,4 +1,6 @@
-import { ChooseOrCreateInstrumentDialog } from "components/instruments/choose-or-create-instrument-dialog";
+import { ConfirmationDialog } from "components/confirmation-dialog";
+import { Flex } from "components/flex";
+import { InstrumentSettings } from "components/instruments/instrument-settings";
 import { InstrumentsTable } from "components/instruments/instruments-table";
 import {
     Pane,
@@ -6,12 +8,15 @@ import {
     EmptyState,
     Icon,
     BanCircleIcon,
+    StepChartIcon,
 } from "evergreen-ui";
 import { RouteProps } from "interfaces/route-props";
 import { InstrumentRecord } from "models/instrument-record";
 import React, { useCallback, useState } from "react";
-import { theme } from "theme";
+import { useDialog } from "utils/hooks/use-dialog";
 import { useGlobalState } from "utils/hooks/use-global-state";
+import { useTheme } from "utils/hooks/use-theme";
+import { useTimeoutRender } from "utils/hooks/use-timeout-render";
 
 interface InstrumentsPageProps extends RouteProps {}
 
@@ -19,33 +24,126 @@ const InstrumentsPage: React.FC<InstrumentsPageProps> = (
     props: InstrumentsPageProps
 ) => {
     const { globalState } = useGlobalState();
+    const { colors, intents } = useTheme();
     const [instrument, setInstrument] = useState<
         InstrumentRecord | undefined
     >();
+    const [initialInstrument, setInitialInstrument] = useState<
+        InstrumentRecord | undefined
+    >();
+    const [
+        confirmationDialogOpen,
+        handleOpenConfirmationDialog,
+        closeConfirmationDialog,
+    ] = useDialog();
+    useTimeoutRender();
 
-    const handleCloseDialog = useCallback(
-        () => setInstrument(undefined),
-        [setInstrument]
-    );
+    const resetInstrument = useCallback(() => {
+        setInstrument(undefined);
+        setInitialInstrument(undefined);
+    }, []);
+
+    const handleCancel = useCallback(() => {
+        if (!initialInstrument?.equals(instrument)) {
+            handleOpenConfirmationDialog();
+            return;
+        }
+
+        resetInstrument();
+    }, [
+        handleOpenConfirmationDialog,
+        initialInstrument,
+        instrument,
+        resetInstrument,
+    ]);
+
+    const handleConfirmDiscardChanges = useCallback(() => {
+        resetInstrument();
+        closeConfirmationDialog();
+    }, [closeConfirmationDialog, resetInstrument]);
+
+    const handleChange = useCallback((instrument: InstrumentRecord) => {
+        setInstrument(instrument);
+    }, []);
+
+    const handleCreateOrUpdate = useCallback((instrument: InstrumentRecord) => {
+        setInstrument(instrument);
+        setInitialInstrument(instrument);
+    }, []);
+
+    const handleCreate = useCallback(() => {
+        const newInstrument = new InstrumentRecord();
+        setInstrument(newInstrument);
+        setInitialInstrument(newInstrument);
+    }, []);
+
+    const handleSelect = useCallback((instrument: InstrumentRecord) => {
+        setInitialInstrument(instrument);
+        setInstrument(instrument);
+    }, []);
+
+    const handleDelete = useCallback(() => {
+        resetInstrument();
+    }, [resetInstrument]);
 
     return (
         <Pane marginRight={majorScale(2)} marginTop={majorScale(1)}>
             {globalState.isAuthenticated() && (
-                <Pane maxWidth={majorScale(80)}>
-                    <InstrumentsTable
-                        isSelectable={true}
-                        onSelect={setInstrument}
-                        selected={instrument}
-                    />
-                    {instrument != null && (
-                        <ChooseOrCreateInstrumentDialog
-                            instrument={instrument}
-                            isShown={true}
-                            onCloseComplete={handleCloseDialog}
-                            showTabs={false}
+                <Flex.Row>
+                    <Pane maxWidth="40%" minWidth="40%">
+                        <InstrumentsTable
+                            isSelectable={true}
+                            onSelect={handleSelect}
+                            selected={initialInstrument}
                         />
-                    )}
-                </Pane>
+                    </Pane>
+                    <Flex.Column
+                        marginLeft={majorScale(2)}
+                        maxWidth="60%"
+                        minWidth="60%">
+                        {instrument != null && (
+                            <Pane maxWidth="75%">
+                                <InstrumentSettings
+                                    confirmLabel="Save"
+                                    instrument={instrument}
+                                    onCancel={handleCancel}
+                                    onChange={handleChange}
+                                    onCreateOrUpdate={handleCreateOrUpdate}
+                                    onDelete={handleDelete}
+                                />
+                            </Pane>
+                        )}
+                        {instrument == null && (
+                            <Pane marginRight={majorScale(2)}>
+                                <EmptyState
+                                    background="dark"
+                                    icon={
+                                        <Icon
+                                            color={colors.gray500}
+                                            icon={StepChartIcon}
+                                        />
+                                    }
+                                    iconBgColor={colors.gray200}
+                                    primaryCta={
+                                        <EmptyState.PrimaryButton
+                                            onClick={handleCreate}>
+                                            Create Instrument
+                                        </EmptyState.PrimaryButton>
+                                    }
+                                    title="Select an Instrument on the left to edit or create a new one."
+                                />
+                            </Pane>
+                        )}
+                        {confirmationDialogOpen && (
+                            <ConfirmationDialog
+                                alertDescription="Cancelling or selecting a new Instrument will discard your changes."
+                                alertTitle="You have unsaved changes."
+                                onCloseComplete={closeConfirmationDialog}
+                                onConfirm={handleConfirmDiscardChanges}
+                            />
+                        )}
+                    </Flex.Column>
+                </Flex.Row>
             )}
             {!globalState.isAuthenticated() && (
                 <Pane maxWidth={majorScale(60)}>
@@ -53,11 +151,11 @@ const InstrumentsPage: React.FC<InstrumentsPageProps> = (
                         background="dark"
                         icon={
                             <Icon
-                                color={theme.intents.danger.icon}
+                                color={intents.danger.icon}
                                 icon={BanCircleIcon}
                             />
                         }
-                        iconBgColor={theme.intents.danger.background}
+                        iconBgColor={intents.danger.background}
                         title="Please register to create instruments."
                     />
                 </Pane>

--- a/src/components/pages/instruments-page.tsx
+++ b/src/components/pages/instruments-page.tsx
@@ -17,6 +17,7 @@ import { useDialog } from "utils/hooks/use-dialog";
 import { useGlobalState } from "utils/hooks/use-global-state";
 import { useTheme } from "utils/hooks/use-theme";
 import { useTimeoutRender } from "utils/hooks/use-timeout-render";
+import { generateId } from "utils/id-utils";
 
 interface InstrumentsPageProps extends RouteProps {}
 
@@ -84,7 +85,9 @@ const InstrumentsPage: React.FC<InstrumentsPageProps> = (
     }, []);
 
     const handleCreate = useCallback(() => {
-        const newInstrument = new InstrumentRecord();
+        const newInstrument = new InstrumentRecord().merge({
+            id: generateId(),
+        });
         setInstrument(newInstrument);
         setInitialInstrument(newInstrument);
     }, []);

--- a/src/components/pages/workstation-page.tsx
+++ b/src/components/pages/workstation-page.tsx
@@ -224,7 +224,6 @@ const WorkstationPage: React.FC<WorkstationPageProps> = (
                         </Pane>
                         {instrumentDialogOpen && (
                             <ChooseOrCreateInstrumentDialog
-                                isShown={true}
                                 onCloseComplete={handleCloseInstrumentDialog}
                                 onSubmit={handleInstrumentSubmit}
                                 showTabs={globalState.isAuthenticated()}

--- a/src/components/piano-roll/piano-roll-dialog.tsx
+++ b/src/components/piano-roll/piano-roll-dialog.tsx
@@ -56,7 +56,6 @@ const PianoRollDialog: React.FC<PianoRollDialogProps> = (
     return (
         <Dialog
             allowFullscreen={true}
-            isShown={true}
             onCloseComplete={onCloseComplete}
             onConfirm={handleConfirm}
             onFullscreenClick={handleFullscreenClick}

--- a/src/components/sequencer/sequencer-dialog.tsx
+++ b/src/components/sequencer/sequencer-dialog.tsx
@@ -63,7 +63,6 @@ const SequencerDialog: React.FC<SequencerDialogProps> = (
 
     return (
         <Dialog
-            isShown={true}
             onCloseComplete={onCloseComplete}
             onConfirm={handleConfirm}
             title="Sequencer">

--- a/src/components/sidebar/about-dialog.tsx
+++ b/src/components/sidebar/about-dialog.tsx
@@ -29,7 +29,6 @@ const AboutDialog: React.FC<AboutDialogProps> = (props: AboutDialogProps) => {
         <Dialog
             confirmLabel="Close"
             hasCancel={false}
-            isShown={true}
             onCloseComplete={onCloseComplete}
             title="About">
             {isLoading && <Spinner />}

--- a/src/components/sidebar/help-dialog/help-dialog.tsx
+++ b/src/components/sidebar/help-dialog/help-dialog.tsx
@@ -76,7 +76,6 @@ const HelpDialog: React.FC<HelpDialogProps> = (props: HelpDialogProps) => {
                     />
                 </React.Fragment>
             }
-            isShown={true}
             onCloseComplete={onCloseComplete}
             onFullscreenClick={handleFullscreenClick}>
             {isLoading && <Spinner />}

--- a/src/components/workstation/export-dialog.tsx
+++ b/src/components/workstation/export-dialog.tsx
@@ -30,8 +30,7 @@ import { isEmpty } from "lodash";
 import { FormField } from "components/forms/form-field";
 import { Flex } from "components/flex";
 
-interface ExportDialogProps
-    extends Pick<DialogProps, "isShown" | "onCloseComplete"> {}
+interface ExportDialogProps extends Pick<DialogProps, "onCloseComplete"> {}
 
 const options: Array<SelectMenuItem<MimeType>> = enumToSelectMenuItems(
     MimeType
@@ -45,7 +44,7 @@ const title = "Export as Audio";
 const ExportDialog: React.FC<ExportDialogProps> = (
     props: ExportDialogProps
 ) => {
-    const { isShown, onCloseComplete } = props;
+    const { onCloseComplete } = props;
     const { colors } = useTheme();
     const { resultObject: files = List(), isLoading: isLoadingFiles } =
         useListFiles();
@@ -123,7 +122,6 @@ const ExportDialog: React.FC<ExportDialogProps> = (
         <Dialog
             confirmLabel="Close"
             hasCancel={false}
-            isShown={isShown}
             onCloseComplete={handleClose}
             shouldCloseOnOverlayClick={false}
             title={title}>

--- a/src/components/workstation/file-tab.tsx
+++ b/src/components/workstation/file-tab.tsx
@@ -207,7 +207,7 @@ const FileTab: React.FC<FileTabProps> = (props: FileTabProps) => {
                         </Menu.Item>
                         <Menu.Item
                             onClick={handleSave(closePopover)}
-                            secondaryText={shortcutKey + "S" as any}>
+                            secondaryText={(shortcutKey + "S") as any}>
                             Save
                         </Menu.Item>
                         <Menu.Item onClick={handleExportClick(closePopover)}>
@@ -251,13 +251,11 @@ const FileTab: React.FC<FileTabProps> = (props: FileTabProps) => {
             </Popover>
             {isSaveProjectDialogOpen && (
                 <SaveProjectDialog
-                    isShown={isSaveProjectDialogOpen}
                     onCloseComplete={handleCloseSaveProjectDialog}
                 />
             )}
             {isOpenProjectDialogOpen && (
                 <OpenProjectDialog
-                    isShown={isOpenProjectDialogOpen}
                     onCloseComplete={handleCloseOpenProjectDialog}
                 />
             )}
@@ -265,22 +263,17 @@ const FileTab: React.FC<FileTabProps> = (props: FileTabProps) => {
                 <ConfirmationDialog
                     alertDescription={alertDecription}
                     alertTitle="You currently have unsaved changes."
-                    isShown={isConfirmDialogOpen}
                     onCloseComplete={handleCloseConfirmDialog}
                     onConfirm={handleDirtyConfirm}
                 />
             )}
             {isSettingsDialogOpen && (
                 <ProjectSettingsDialog
-                    isShown={isSettingsDialogOpen}
                     onCloseComplete={handleCloseSettingsDialog}
                 />
             )}
             {isExportDialogOpen && (
-                <ExportDialog
-                    isShown={isExportDialogOpen}
-                    onCloseComplete={handleCloseExportDialog}
-                />
+                <ExportDialog onCloseComplete={handleCloseExportDialog} />
             )}
         </React.Fragment>
     );

--- a/src/components/workstation/open-project-dialog.tsx
+++ b/src/components/workstation/open-project-dialog.tsx
@@ -10,13 +10,12 @@ import { useTheme } from "utils/hooks/use-theme";
 import { useWorkstationState } from "utils/hooks/use-workstation-state";
 import { Dialog, DialogProps } from "components/dialog";
 
-interface OpenProjectDialogProps
-    extends Pick<DialogProps, "isShown" | "onCloseComplete"> {}
+interface OpenProjectDialogProps extends Pick<DialogProps, "onCloseComplete"> {}
 
 const OpenProjectDialog: React.FC<OpenProjectDialogProps> = (
     props: OpenProjectDialogProps
 ) => {
-    const { isShown, onCloseComplete } = props;
+    const { onCloseComplete } = props;
     const theme = useTheme();
     const { isDirty, state, setState } = useWorkstationState();
     const { resultObject: workstations, isLoading } = useListWorkstations({});
@@ -64,7 +63,6 @@ const OpenProjectDialog: React.FC<OpenProjectDialogProps> = (
                     selected?.equals(state.project)
                 }
                 isConfirmLoading={false}
-                isShown={isShown}
                 onCloseComplete={onCloseComplete}
                 onConfirm={handleConfirm}
                 shouldCloseOnOverlayClick={false}
@@ -123,7 +121,6 @@ const OpenProjectDialog: React.FC<OpenProjectDialogProps> = (
                 <ConfirmationDialog
                     alertDescription="Opening a new project will wipe out any unsaved changes."
                     alertTitle="You currently have unsaved changes."
-                    isShown={isConfirmDialogOpen}
                     onCloseComplete={handleCloseConfirmDialog}
                     onConfirm={handleDirtyConfirm}
                 />

--- a/src/components/workstation/project-settings-dialog.tsx
+++ b/src/components/workstation/project-settings-dialog.tsx
@@ -11,12 +11,12 @@ import { useWorkstationState } from "utils/hooks/use-workstation-state";
 import { Dialog, DialogProps } from "components/dialog";
 
 interface ProjectSettingsDialogProps
-    extends Pick<DialogProps, "isShown" | "onCloseComplete"> {}
+    extends Pick<DialogProps, "onCloseComplete"> {}
 
 const ProjectSettingsDialog: React.FC<ProjectSettingsDialogProps> = (
     props: ProjectSettingsDialogProps
 ) => {
-    const { isShown, onCloseComplete } = props;
+    const { onCloseComplete } = props;
     const title = "Project Settings";
     const { state, setState } = useWorkstationState();
     const { state: project, setCurrentState: setCurrentProject } =
@@ -62,7 +62,6 @@ const ProjectSettingsDialog: React.FC<ProjectSettingsDialogProps> = (
     return (
         <Dialog
             isConfirmDisabled={isAttemptingDelete}
-            isShown={isShown}
             onCloseComplete={onCloseComplete}
             onConfirm={handleConfirm}
             shouldCloseOnOverlayClick={false}

--- a/src/components/workstation/save-project-dialog.tsx
+++ b/src/components/workstation/save-project-dialog.tsx
@@ -19,14 +19,13 @@ import { useTheme } from "utils/hooks/use-theme";
 import { useWorkstationState } from "utils/hooks/use-workstation-state";
 import { Dialog, DialogProps } from "components/dialog";
 
-interface SaveProjectDialogProps
-    extends Pick<DialogProps, "isShown" | "onCloseComplete"> {}
+interface SaveProjectDialogProps extends Pick<DialogProps, "onCloseComplete"> {}
 
 const SaveProjectDialog: React.FC<SaveProjectDialogProps> = (
     props: SaveProjectDialogProps
 ) => {
     const { isAuthenticated } = useGlobalState();
-    const { isShown, onCloseComplete } = props;
+    const { onCloseComplete } = props;
     const { state, setState } = useWorkstationState();
     const theme = useTheme();
     const title = "New Project";
@@ -75,7 +74,6 @@ const SaveProjectDialog: React.FC<SaveProjectDialogProps> = (
             confirmLabel={isAuthenticated ? "Save" : "Done"}
             hasCancel={isAuthenticated}
             isConfirmLoading={isLoading}
-            isShown={isShown}
             onCloseComplete={onCloseComplete}
             onConfirm={handleConfirm}
             shouldCloseOnOverlayClick={false}

--- a/src/interfaces/tone-track.ts
+++ b/src/interfaces/tone-track.ts
@@ -1,7 +1,9 @@
 import Tone from "tone";
+import { MidiNote } from "types/midi-note";
 
 interface ToneTrack {
     channel: Tone.Channel;
+    sampleMap: Record<MidiNote, string>;
     sampler: Tone.Sampler;
     sequence: Tone.Sequence;
 }

--- a/src/models/instrument-record.ts
+++ b/src/models/instrument-record.ts
@@ -5,15 +5,16 @@ import { Instrument } from "generated/interfaces/instrument";
 import { AuditableDefaultValues } from "constants/auditable-default-values";
 import { InstrumentCurve } from "generated/enums/instrument-curve";
 import { AuditableRecord } from "models/auditable-record";
+import { defaultNote } from "constants/midi-notes";
 
 const defaultValues = makeDefaultValues<Instrument>({
     ...AuditableDefaultValues,
     curve: InstrumentCurve.Exponential,
-    duration: undefined,
+    duration: null,
     file_id: undefined,
-    name: undefined,
+    name: "",
     release: 0.1,
-    root_note: undefined,
+    root_note: defaultNote,
 });
 
 class InstrumentRecord

--- a/src/types/required-or-nil.ts
+++ b/src/types/required-or-nil.ts
@@ -1,0 +1,5 @@
+import { RequiredOr } from "types/required-or";
+
+type RequiredOrNil<T> = RequiredOr<T, undefined | null>;
+
+export type { RequiredOrNil };

--- a/src/types/required-or-null.ts
+++ b/src/types/required-or-null.ts
@@ -1,5 +1,0 @@
-import { RequiredOr } from "types/required-or";
-
-type RequiredOrNull<T> = RequiredOr<T, null>;
-
-export type { RequiredOrNull as RequiredOrNull };

--- a/src/types/required-or-undefined.ts
+++ b/src/types/required-or-undefined.ts
@@ -1,5 +1,0 @@
-import { RequiredOr } from "types/required-or";
-
-type RequiredOrUndefined<T> = RequiredOr<T, undefined>;
-
-export type { RequiredOrUndefined };

--- a/src/utils/core-utils.ts
+++ b/src/utils/core-utils.ts
@@ -1,6 +1,6 @@
 import { BorderPropsOptions } from "interfaces/border-props-options";
 import { BorderProps } from "interfaces/border-props";
-import { RequiredOrUndefined } from "types/required-or-undefined";
+import { RequiredOrNil } from "types/required-or-nil";
 import { List, Record } from "immutable";
 import { isEqual as lodashIsEqual } from "lodash";
 
@@ -81,7 +81,7 @@ const isNotNilOrEmpty = <T = string | any[] | List<any>>(
     value: T | any[] | List<any> | null | undefined
 ): value is T => !isNilOrEmpty(value);
 
-const makeDefaultValues = <T>(defaultValues: RequiredOrUndefined<T>): T =>
+const makeDefaultValues = <T>(defaultValues: RequiredOrNil<T>): T =>
     defaultValues as T;
 
 const randomFloat = (min: number, max: number): number =>


### PR DESCRIPTION
Resolves #60
Resolves #115

- Updates `InstrumentsPage` to render the `InstrumentSettings` component on the right side of the page to create or edit Instruments.
![image](https://user-images.githubusercontent.com/11774799/165856745-dd38a31e-5ec2-45b8-a71a-43594db3db8f.png)

    - If no Instruments currently exist, an empty state is rendered inside the table with a CTA to create a new one.
    
    - ![image](https://user-images.githubusercontent.com/11774799/165856544-61acc002-fab6-4b89-99a7-a0a779f32788.png)

    - If Instruments exist and one has not been selected for editing, an empty state is rendered on the right side of the page with a CTA to create a new one
    
    - ![image](https://user-images.githubusercontent.com/11774799/165856466-86e59b7e-be47-437e-9823-06d55703518f.png)

- Fixed the bug where the Instrument preview functionality wouldn't work until persisted (this was initially caused by an `undefined` id on creation, however, I also found an issue where the proper sample wasn't playing after changing files. This should be fixed now.)