### PR TITLE
Add Slider, persist volume for Track

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "beets",
             "version": "0.0.0",
             "dependencies": {
+                "@mantine/core": "4.2.1",
                 "@octokit/rest": "18.12.0",
                 "@supabase/supabase-js": "1.35.2",
                 "evergreen-ui": "6.9.8",
@@ -1950,10 +1951,150 @@
             "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
             "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
         },
+        "node_modules/@emotion/babel-plugin": {
+            "version": "11.9.2",
+            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.9.2.tgz",
+            "integrity": "sha512-Pr/7HGH6H6yKgnVFNEj2MVlreu3ADqftqjqwUvDy/OJzKFgxKeTQ+eeUf20FOTuHVkDON2iNa25rAXVYtWJCjw==",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.12.13",
+                "@babel/plugin-syntax-jsx": "^7.12.13",
+                "@babel/runtime": "^7.13.10",
+                "@emotion/hash": "^0.8.0",
+                "@emotion/memoize": "^0.7.5",
+                "@emotion/serialize": "^1.0.2",
+                "babel-plugin-macros": "^2.6.1",
+                "convert-source-map": "^1.5.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-root": "^1.1.0",
+                "source-map": "^0.5.7",
+                "stylis": "4.0.13"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@emotion/babel-plugin/node_modules/@babel/runtime": {
+            "version": "7.17.9",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+            "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+            "dependencies": {
+                "regenerator-runtime": "^0.13.4"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@emotion/babel-plugin/node_modules/@emotion/hash": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+            "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+        },
+        "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@emotion/cache": {
+            "version": "11.7.1",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+            "integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
+            "dependencies": {
+                "@emotion/memoize": "^0.7.4",
+                "@emotion/sheet": "^1.1.0",
+                "@emotion/utils": "^1.0.0",
+                "@emotion/weak-memoize": "^0.2.5",
+                "stylis": "4.0.13"
+            }
+        },
         "node_modules/@emotion/hash": {
             "version": "0.7.4",
             "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.4.tgz",
             "integrity": "sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A=="
+        },
+        "node_modules/@emotion/memoize": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+            "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
+        },
+        "node_modules/@emotion/react": {
+            "version": "11.9.0",
+            "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.9.0.tgz",
+            "integrity": "sha512-lBVSF5d0ceKtfKCDQJveNAtkC7ayxpVlgOohLgXqRwqWr9bOf4TZAFFyIcNngnV6xK6X4x2ZeXq7vliHkoVkxQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@emotion/babel-plugin": "^11.7.1",
+                "@emotion/cache": "^11.7.1",
+                "@emotion/serialize": "^1.0.3",
+                "@emotion/utils": "^1.1.0",
+                "@emotion/weak-memoize": "^0.2.5",
+                "hoist-non-react-statics": "^3.3.1"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0",
+                "react": ">=16.8.0"
+            },
+            "peerDependenciesMeta": {
+                "@babel/core": {
+                    "optional": true
+                },
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@emotion/react/node_modules/@babel/runtime": {
+            "version": "7.17.9",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+            "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+            "dependencies": {
+                "regenerator-runtime": "^0.13.4"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@emotion/serialize": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.3.tgz",
+            "integrity": "sha512-2mSSvgLfyV3q+iVh3YWgNlUc2a9ZlDU7DjuP5MjK3AXRR0dYigCrP99aeFtaB2L/hjfEZdSThn5dsZ0ufqbvsA==",
+            "dependencies": {
+                "@emotion/hash": "^0.8.0",
+                "@emotion/memoize": "^0.7.4",
+                "@emotion/unitless": "^0.7.5",
+                "@emotion/utils": "^1.0.0",
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@emotion/serialize/node_modules/@emotion/hash": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+            "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+        },
+        "node_modules/@emotion/sheet": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
+            "integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
+        },
+        "node_modules/@emotion/unitless": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+            "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+        },
+        "node_modules/@emotion/utils": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.1.0.tgz",
+            "integrity": "sha512-iRLa/Y4Rs5H/f2nimczYmS5kFJEbpiVvgN3XVfZ022IYhuNA1IRSHEizcof88LtCTXtl9S2Cxt32KgaXEu72JQ=="
+        },
+        "node_modules/@emotion/weak-memoize": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+            "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
         },
         "node_modules/@eslint/eslintrc": {
             "version": "0.4.3",
@@ -2455,6 +2596,212 @@
                 "node": ">= 10.14.2"
             }
         },
+        "node_modules/@mantine/core": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@mantine/core/-/core-4.2.1.tgz",
+            "integrity": "sha512-YEz0SG8HN+H1s/gpqEzSUUFPXdaMQnZgJPO8JTOgX/qlVvggw+Y8TaLby4A+4kgQdGiXTWxr1Njx1/u72Fa1KA==",
+            "dependencies": {
+                "@mantine/styles": "4.2.1",
+                "@popperjs/core": "^2.9.3",
+                "@radix-ui/react-scroll-area": "^0.1.1",
+                "react-popper": "^2.2.5",
+                "react-textarea-autosize": "^8.3.2"
+            },
+            "peerDependencies": {
+                "@mantine/hooks": "4.2.1",
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "node_modules/@mantine/core/node_modules/@babel/runtime": {
+            "version": "7.17.9",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+            "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+            "dependencies": {
+                "regenerator-runtime": "^0.13.4"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@mantine/core/node_modules/@radix-ui/react-scroll-area": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-0.1.4.tgz",
+            "integrity": "sha512-QHxRsjy+hsHwQYJ9cCNgSJ5+6ioZu1KhwD1UOXoHNciuFGMX08v+uJPKXIz+ySv03Rx6cOz6f/Fk5aPHRMFi/A==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/number": "0.1.0",
+                "@radix-ui/primitive": "0.1.0",
+                "@radix-ui/react-compose-refs": "0.1.0",
+                "@radix-ui/react-context": "0.1.1",
+                "@radix-ui/react-presence": "0.1.2",
+                "@radix-ui/react-primitive": "0.1.4",
+                "@radix-ui/react-use-callback-ref": "0.1.0",
+                "@radix-ui/react-use-direction": "0.1.0",
+                "@radix-ui/react-use-layout-effect": "0.1.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8 || ^17.0"
+            }
+        },
+        "node_modules/@mantine/core/node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-compose-refs": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.0.tgz",
+            "integrity": "sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "react": "^16.8 || ^17.0"
+            }
+        },
+        "node_modules/@mantine/core/node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-context": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-0.1.1.tgz",
+            "integrity": "sha512-PkyVX1JsLBioeu0jB9WvRpDBBLtLZohVDT3BB5CTSJqActma8S8030P57mWZb4baZifMvN7KKWPAA40UmWKkQg==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "react": "^16.8 || ^17.0"
+            }
+        },
+        "node_modules/@mantine/core/node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-presence": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-0.1.2.tgz",
+            "integrity": "sha512-3BRlFZraooIUfRlyN+b/Xs5hq1lanOOo/+3h6Pwu2GMFjkGKKa4Rd51fcqGqnVlbr3jYg+WLuGyAV4KlgqwrQw==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-compose-refs": "0.1.0",
+                "@radix-ui/react-use-layout-effect": "0.1.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8"
+            }
+        },
+        "node_modules/@mantine/core/node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-primitive": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.4.tgz",
+            "integrity": "sha512-6gSl2IidySupIMJFjYnDIkIWRyQdbu/AHK7rbICPani+LW4b0XdxBXc46og/iZvuwW8pjCS8I2SadIerv84xYA==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-slot": "0.1.2"
+            },
+            "peerDependencies": {
+                "react": "^16.8 || ^17.0"
+            }
+        },
+        "node_modules/@mantine/core/node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
+            "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-compose-refs": "0.1.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8 || ^17.0"
+            }
+        },
+        "node_modules/@mantine/core/node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-use-callback-ref": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
+            "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "react": "^16.8 || ^17.0"
+            }
+        },
+        "node_modules/@mantine/core/node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-use-direction": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-direction/-/react-use-direction-0.1.0.tgz",
+            "integrity": "sha512-NajpY/An9TCPSfOVkgWIdXJV+VuWl67PxB6kOKYmtNAFHvObzIoh8o0n9sAuwSAyFCZVq211FEf9gvVDRhOyiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "react": "^16.8 || ^17.0"
+            }
+        },
+        "node_modules/@mantine/core/node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-use-layout-effect": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
+            "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "react": "^16.8 || ^17.0"
+            }
+        },
+        "node_modules/@mantine/core/node_modules/react-textarea-autosize": {
+            "version": "8.3.3",
+            "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz",
+            "integrity": "sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.10.2",
+                "use-composed-ref": "^1.0.0",
+                "use-latest": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@mantine/core/node_modules/react-textarea-autosize/node_modules/use-composed-ref": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+            "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@mantine/core/node_modules/react-textarea-autosize/node_modules/use-latest": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+            "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+            "dependencies": {
+                "use-isomorphic-layout-effect": "^1.1.1"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mantine/hooks": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-4.2.1.tgz",
+            "integrity": "sha512-+sg8aBK1IzCLGrtL2PEUp1q2/3blUvxJPoqIE6wwcvtIc7cFYfPWRdFFRtkwJjHQ+KlH6TvCO0Yl7F6FBq7+Rw==",
+            "peer": true,
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/@mantine/styles": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@mantine/styles/-/styles-4.2.1.tgz",
+            "integrity": "sha512-KHQDCFh4tOBYjKZ7Y5f7qhVXQDKDAhuQz2jJeSE9rUrUaXtJJaAvlrV884AD2vx58k2UUKpAAaBt8CaT1VAXgw==",
+            "dependencies": {
+                "@emotion/cache": "^11.7.1",
+                "@emotion/react": "^11.7.1",
+                "@emotion/serialize": "^1.0.2",
+                "@emotion/utils": "^1.0.0",
+                "clsx": "^1.1.1",
+                "csstype": "^3.0.9"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2728,6 +3075,53 @@
             "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@popperjs/core": {
+            "version": "2.11.5",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+            "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/popperjs"
+            }
+        },
+        "node_modules/@radix-ui/number": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-0.1.0.tgz",
+            "integrity": "sha512-rpf6QiOWLHAkM4FEMYu9i+5Jr8cKT893+R4mPpcdsy4LD7omr9JfdOqj/h/xPA5+EcVrpMMlU6rrRYpUB5UI8g==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            }
+        },
+        "node_modules/@radix-ui/number/node_modules/@babel/runtime": {
+            "version": "7.17.9",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+            "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+            "dependencies": {
+                "regenerator-runtime": "^0.13.4"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@radix-ui/primitive": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-0.1.0.tgz",
+            "integrity": "sha512-tqxZKybwN5Fa3VzZry4G6mXAAb9aAqKmPtnVbZpL0vsBwvOHTBwsjHVPXylocYLwEtBY9SCe665bYnNB515uoA==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            }
+        },
+        "node_modules/@radix-ui/primitive/node_modules/@babel/runtime": {
+            "version": "7.17.9",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+            "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+            "dependencies": {
+                "regenerator-runtime": "^0.13.4"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@rollup/plugin-node-resolve": {
@@ -6144,6 +6538,14 @@
                 "wrap-ansi": "^6.2.0"
             }
         },
+        "node_modules/clsx": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+            "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -7206,9 +7608,9 @@
             "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
         },
         "node_modules/csstype": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
-            "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+            "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
         },
         "node_modules/cyclist": {
             "version": "1.0.1",
@@ -9708,6 +10110,11 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
         },
         "node_modules/find-up": {
             "version": "4.1.0",
@@ -18079,6 +18486,20 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.0.0.tgz",
             "integrity": "sha512-yUcBYdBBbo3QiPsgYDcfQcIkGZHfxOaoE6HLSnr1sPzMhdyxusbfKOSUbSd/ocGi32dxcj366PsTj+5oggeKKw=="
         },
+        "node_modules/react-popper": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+            "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+            "dependencies": {
+                "react-fast-compare": "^3.0.1",
+                "warning": "^4.0.2"
+            },
+            "peerDependencies": {
+                "@popperjs/core": "^2.0.0",
+                "react": "^16.8.0 || ^17 || ^18",
+                "react-dom": "^16.8.0 || ^17 || ^18"
+            }
+        },
         "node_modules/react-query": {
             "version": "3.38.0",
             "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.38.0.tgz",
@@ -20670,6 +21091,11 @@
                 "node": ">=8"
             }
         },
+        "node_modules/stylis": {
+            "version": "4.0.13",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
+            "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -21981,6 +22407,19 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/use-isomorphic-layout-effect": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+            "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/utf-8-validate": {
             "version": "5.0.5",
             "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.5.tgz",
@@ -22209,6 +22648,14 @@
             "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
             "dependencies": {
                 "makeerror": "1.0.x"
+            }
+        },
+        "node_modules/warning": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+            "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+            "dependencies": {
+                "loose-envify": "^1.0.0"
             }
         },
         "node_modules/watchpack": {
@@ -25357,10 +25804,129 @@
             "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
             "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
         },
+        "@emotion/babel-plugin": {
+            "version": "11.9.2",
+            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.9.2.tgz",
+            "integrity": "sha512-Pr/7HGH6H6yKgnVFNEj2MVlreu3ADqftqjqwUvDy/OJzKFgxKeTQ+eeUf20FOTuHVkDON2iNa25rAXVYtWJCjw==",
+            "requires": {
+                "@babel/helper-module-imports": "^7.12.13",
+                "@babel/plugin-syntax-jsx": "^7.12.13",
+                "@babel/runtime": "^7.13.10",
+                "@emotion/hash": "^0.8.0",
+                "@emotion/memoize": "^0.7.5",
+                "@emotion/serialize": "^1.0.2",
+                "babel-plugin-macros": "^2.6.1",
+                "convert-source-map": "^1.5.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-root": "^1.1.0",
+                "source-map": "^0.5.7",
+                "stylis": "4.0.13"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.17.9",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+                    "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+                    "requires": {
+                        "regenerator-runtime": "^0.13.4"
+                    }
+                },
+                "@emotion/hash": {
+                    "version": "0.8.0",
+                    "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+                    "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+                },
+                "escape-string-regexp": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+                }
+            }
+        },
+        "@emotion/cache": {
+            "version": "11.7.1",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+            "integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
+            "requires": {
+                "@emotion/memoize": "^0.7.4",
+                "@emotion/sheet": "^1.1.0",
+                "@emotion/utils": "^1.0.0",
+                "@emotion/weak-memoize": "^0.2.5",
+                "stylis": "4.0.13"
+            }
+        },
         "@emotion/hash": {
             "version": "0.7.4",
             "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.4.tgz",
             "integrity": "sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A=="
+        },
+        "@emotion/memoize": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+            "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
+        },
+        "@emotion/react": {
+            "version": "11.9.0",
+            "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.9.0.tgz",
+            "integrity": "sha512-lBVSF5d0ceKtfKCDQJveNAtkC7ayxpVlgOohLgXqRwqWr9bOf4TZAFFyIcNngnV6xK6X4x2ZeXq7vliHkoVkxQ==",
+            "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@emotion/babel-plugin": "^11.7.1",
+                "@emotion/cache": "^11.7.1",
+                "@emotion/serialize": "^1.0.3",
+                "@emotion/utils": "^1.1.0",
+                "@emotion/weak-memoize": "^0.2.5",
+                "hoist-non-react-statics": "^3.3.1"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.17.9",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+                    "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+                    "requires": {
+                        "regenerator-runtime": "^0.13.4"
+                    }
+                }
+            }
+        },
+        "@emotion/serialize": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.3.tgz",
+            "integrity": "sha512-2mSSvgLfyV3q+iVh3YWgNlUc2a9ZlDU7DjuP5MjK3AXRR0dYigCrP99aeFtaB2L/hjfEZdSThn5dsZ0ufqbvsA==",
+            "requires": {
+                "@emotion/hash": "^0.8.0",
+                "@emotion/memoize": "^0.7.4",
+                "@emotion/unitless": "^0.7.5",
+                "@emotion/utils": "^1.0.0",
+                "csstype": "^3.0.2"
+            },
+            "dependencies": {
+                "@emotion/hash": {
+                    "version": "0.8.0",
+                    "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+                    "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+                }
+            }
+        },
+        "@emotion/sheet": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
+            "integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
+        },
+        "@emotion/unitless": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+            "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+        },
+        "@emotion/utils": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.1.0.tgz",
+            "integrity": "sha512-iRLa/Y4Rs5H/f2nimczYmS5kFJEbpiVvgN3XVfZ022IYhuNA1IRSHEizcof88LtCTXtl9S2Cxt32KgaXEu72JQ=="
+        },
+        "@emotion/weak-memoize": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+            "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
         },
         "@eslint/eslintrc": {
             "version": "0.4.3",
@@ -25766,6 +26332,163 @@
                 "chalk": "^4.0.0"
             }
         },
+        "@mantine/core": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@mantine/core/-/core-4.2.1.tgz",
+            "integrity": "sha512-YEz0SG8HN+H1s/gpqEzSUUFPXdaMQnZgJPO8JTOgX/qlVvggw+Y8TaLby4A+4kgQdGiXTWxr1Njx1/u72Fa1KA==",
+            "requires": {
+                "@mantine/styles": "4.2.1",
+                "@popperjs/core": "^2.9.3",
+                "@radix-ui/react-scroll-area": "^0.1.1",
+                "react-popper": "^2.2.5",
+                "react-textarea-autosize": "^8.3.2"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.17.9",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+                    "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+                    "requires": {
+                        "regenerator-runtime": "^0.13.4"
+                    }
+                },
+                "@radix-ui/react-scroll-area": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-0.1.4.tgz",
+                    "integrity": "sha512-QHxRsjy+hsHwQYJ9cCNgSJ5+6ioZu1KhwD1UOXoHNciuFGMX08v+uJPKXIz+ySv03Rx6cOz6f/Fk5aPHRMFi/A==",
+                    "requires": {
+                        "@babel/runtime": "^7.13.10",
+                        "@radix-ui/number": "0.1.0",
+                        "@radix-ui/primitive": "0.1.0",
+                        "@radix-ui/react-compose-refs": "0.1.0",
+                        "@radix-ui/react-context": "0.1.1",
+                        "@radix-ui/react-presence": "0.1.2",
+                        "@radix-ui/react-primitive": "0.1.4",
+                        "@radix-ui/react-use-callback-ref": "0.1.0",
+                        "@radix-ui/react-use-direction": "0.1.0",
+                        "@radix-ui/react-use-layout-effect": "0.1.0"
+                    },
+                    "dependencies": {
+                        "@radix-ui/react-compose-refs": {
+                            "version": "0.1.0",
+                            "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.0.tgz",
+                            "integrity": "sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==",
+                            "requires": {
+                                "@babel/runtime": "^7.13.10"
+                            }
+                        },
+                        "@radix-ui/react-context": {
+                            "version": "0.1.1",
+                            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-0.1.1.tgz",
+                            "integrity": "sha512-PkyVX1JsLBioeu0jB9WvRpDBBLtLZohVDT3BB5CTSJqActma8S8030P57mWZb4baZifMvN7KKWPAA40UmWKkQg==",
+                            "requires": {
+                                "@babel/runtime": "^7.13.10"
+                            }
+                        },
+                        "@radix-ui/react-presence": {
+                            "version": "0.1.2",
+                            "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-0.1.2.tgz",
+                            "integrity": "sha512-3BRlFZraooIUfRlyN+b/Xs5hq1lanOOo/+3h6Pwu2GMFjkGKKa4Rd51fcqGqnVlbr3jYg+WLuGyAV4KlgqwrQw==",
+                            "requires": {
+                                "@babel/runtime": "^7.13.10",
+                                "@radix-ui/react-compose-refs": "0.1.0",
+                                "@radix-ui/react-use-layout-effect": "0.1.0"
+                            }
+                        },
+                        "@radix-ui/react-primitive": {
+                            "version": "0.1.4",
+                            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.4.tgz",
+                            "integrity": "sha512-6gSl2IidySupIMJFjYnDIkIWRyQdbu/AHK7rbICPani+LW4b0XdxBXc46og/iZvuwW8pjCS8I2SadIerv84xYA==",
+                            "requires": {
+                                "@babel/runtime": "^7.13.10",
+                                "@radix-ui/react-slot": "0.1.2"
+                            },
+                            "dependencies": {
+                                "@radix-ui/react-slot": {
+                                    "version": "0.1.2",
+                                    "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
+                                    "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
+                                    "requires": {
+                                        "@babel/runtime": "^7.13.10",
+                                        "@radix-ui/react-compose-refs": "0.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "@radix-ui/react-use-callback-ref": {
+                            "version": "0.1.0",
+                            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
+                            "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
+                            "requires": {
+                                "@babel/runtime": "^7.13.10"
+                            }
+                        },
+                        "@radix-ui/react-use-direction": {
+                            "version": "0.1.0",
+                            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-direction/-/react-use-direction-0.1.0.tgz",
+                            "integrity": "sha512-NajpY/An9TCPSfOVkgWIdXJV+VuWl67PxB6kOKYmtNAFHvObzIoh8o0n9sAuwSAyFCZVq211FEf9gvVDRhOyiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.13.10"
+                            }
+                        },
+                        "@radix-ui/react-use-layout-effect": {
+                            "version": "0.1.0",
+                            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
+                            "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
+                            "requires": {
+                                "@babel/runtime": "^7.13.10"
+                            }
+                        }
+                    }
+                },
+                "react-textarea-autosize": {
+                    "version": "8.3.3",
+                    "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz",
+                    "integrity": "sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==",
+                    "requires": {
+                        "@babel/runtime": "^7.10.2",
+                        "use-composed-ref": "^1.0.0",
+                        "use-latest": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "use-composed-ref": {
+                            "version": "1.3.0",
+                            "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+                            "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+                            "requires": {}
+                        },
+                        "use-latest": {
+                            "version": "1.2.1",
+                            "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+                            "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+                            "requires": {
+                                "use-isomorphic-layout-effect": "^1.1.1"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "@mantine/hooks": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-4.2.1.tgz",
+            "integrity": "sha512-+sg8aBK1IzCLGrtL2PEUp1q2/3blUvxJPoqIE6wwcvtIc7cFYfPWRdFFRtkwJjHQ+KlH6TvCO0Yl7F6FBq7+Rw==",
+            "peer": true,
+            "requires": {}
+        },
+        "@mantine/styles": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@mantine/styles/-/styles-4.2.1.tgz",
+            "integrity": "sha512-KHQDCFh4tOBYjKZ7Y5f7qhVXQDKDAhuQz2jJeSE9rUrUaXtJJaAvlrV884AD2vx58k2UUKpAAaBt8CaT1VAXgw==",
+            "requires": {
+                "@emotion/cache": "^11.7.1",
+                "@emotion/react": "^11.7.1",
+                "@emotion/serialize": "^1.0.2",
+                "@emotion/utils": "^1.0.0",
+                "clsx": "^1.1.1",
+                "csstype": "^3.0.9"
+            }
+        },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -25975,6 +26698,47 @@
                     "version": "0.7.3",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
                     "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+                }
+            }
+        },
+        "@popperjs/core": {
+            "version": "2.11.5",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+            "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
+        },
+        "@radix-ui/number": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-0.1.0.tgz",
+            "integrity": "sha512-rpf6QiOWLHAkM4FEMYu9i+5Jr8cKT893+R4mPpcdsy4LD7omr9JfdOqj/h/xPA5+EcVrpMMlU6rrRYpUB5UI8g==",
+            "requires": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.17.9",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+                    "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+                    "requires": {
+                        "regenerator-runtime": "^0.13.4"
+                    }
+                }
+            }
+        },
+        "@radix-ui/primitive": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-0.1.0.tgz",
+            "integrity": "sha512-tqxZKybwN5Fa3VzZry4G6mXAAb9aAqKmPtnVbZpL0vsBwvOHTBwsjHVPXylocYLwEtBY9SCe665bYnNB515uoA==",
+            "requires": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.17.9",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+                    "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+                    "requires": {
+                        "regenerator-runtime": "^0.13.4"
+                    }
                 }
             }
         },
@@ -28730,6 +29494,11 @@
                 "wrap-ansi": "^6.2.0"
             }
         },
+        "clsx": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+            "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+        },
         "co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -29580,9 +30349,9 @@
             }
         },
         "csstype": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
-            "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+            "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
         },
         "cyclist": {
             "version": "1.0.1",
@@ -31509,6 +32278,11 @@
                     }
                 }
             }
+        },
+        "find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
         },
         "find-up": {
             "version": "4.1.0",
@@ -37856,6 +38630,15 @@
                 }
             }
         },
+        "react-popper": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+            "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+            "requires": {
+                "react-fast-compare": "^3.0.1",
+                "warning": "^4.0.2"
+            }
+        },
         "react-query": {
             "version": "3.38.0",
             "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.38.0.tgz",
@@ -39905,6 +40688,11 @@
                 }
             }
         },
+        "stylis": {
+            "version": "4.0.13",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
+            "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
+        },
         "supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -40876,6 +41664,12 @@
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
         },
+        "use-isomorphic-layout-effect": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+            "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+            "requires": {}
+        },
         "utf-8-validate": {
             "version": "5.0.5",
             "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.5.tgz",
@@ -41052,6 +41846,14 @@
             "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
             "requires": {
                 "makeerror": "1.0.x"
+            }
+        },
+        "warning": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+            "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+            "requires": {
+                "loose-envify": "^1.0.0"
             }
         },
         "watchpack": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.0",
             "dependencies": {
                 "@mantine/core": "4.2.1",
+                "@mantine/hooks": "4.2.1",
                 "@octokit/rest": "18.12.0",
                 "@supabase/supabase-js": "1.35.2",
                 "evergreen-ui": "6.9.8",
@@ -2780,7 +2781,6 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-4.2.1.tgz",
             "integrity": "sha512-+sg8aBK1IzCLGrtL2PEUp1q2/3blUvxJPoqIE6wwcvtIc7cFYfPWRdFFRtkwJjHQ+KlH6TvCO0Yl7F6FBq7+Rw==",
-            "peer": true,
             "peerDependencies": {
                 "react": ">=16.8.0"
             }
@@ -26473,7 +26473,6 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-4.2.1.tgz",
             "integrity": "sha512-+sg8aBK1IzCLGrtL2PEUp1q2/3blUvxJPoqIE6wwcvtIc7cFYfPWRdFFRtkwJjHQ+KlH6TvCO0Yl7F6FBq7+Rw==",
-            "peer": true,
             "requires": {}
         },
         "@mantine/styles": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         ]
     },
     "dependencies": {
+        "@mantine/core": "4.2.1",
         "@octokit/rest": "18.12.0",
         "@supabase/supabase-js": "1.35.2",
         "evergreen-ui": "6.9.8",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     },
     "dependencies": {
         "@mantine/core": "4.2.1",
+        "@mantine/hooks": "4.2.1",
         "@octokit/rest": "18.12.0",
         "@supabase/supabase-js": "1.35.2",
         "evergreen-ui": "6.9.8",

--- a/src/components/mantine/slider.tsx
+++ b/src/components/mantine/slider.tsx
@@ -1,0 +1,53 @@
+import { Slider as MantineSlider } from "@mantine/core";
+import { Flex } from "components/flex";
+import { majorScale, PaneProps, Label } from "evergreen-ui";
+import { isEmpty } from "lodash";
+
+interface SliderProps extends Omit<PaneProps, "onChange" | "value"> {
+    defaultValue?: number;
+    label?: string;
+    max?: number;
+    min?: number;
+    onChange?: (value: number) => void;
+    onChangeEnd?: (value: number) => void;
+    value?: number;
+}
+
+const defaultDefaultValue = 0;
+const defaultMax = 12;
+const defaultMin = -12;
+
+const Slider: React.FC<SliderProps> = (props: SliderProps) => {
+    const {
+        label,
+        onChange,
+        onChangeEnd,
+        value,
+        defaultValue = defaultDefaultValue,
+        min = defaultMin,
+        max = defaultMax,
+        ...rest
+    } = props;
+    const renderLabel = !isEmpty(label);
+    return (
+        <Flex.Column width={majorScale(8)} {...rest}>
+            {renderLabel && (
+                <Label fontSize="x-small" textTransform="uppercase">
+                    {label}
+                </Label>
+            )}
+            <MantineSlider
+                defaultValue={defaultValue}
+                max={max}
+                min={min}
+                onChange={onChange}
+                onChangeEnd={onChangeEnd}
+                radius="sm"
+                size="sm"
+                value={value}
+            />
+        </Flex.Column>
+    );
+};
+
+export { Slider };

--- a/src/components/tracks/track-card/track-card.tsx
+++ b/src/components/tracks/track-card/track-card.tsx
@@ -14,7 +14,7 @@ import {
     VolumeOffIcon,
     VolumeUpIcon,
 } from "evergreen-ui";
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { TrackRecord } from "models/track-record";
 import { useTheme } from "utils/hooks/use-theme";
 import { useTracksState } from "utils/hooks/use-tracks-state";
@@ -31,17 +31,20 @@ import { css, select } from "glamor";
 import { TrackTime } from "components/tracks/track-time/track-time";
 import { useWorkstationState } from "utils/hooks/use-workstation-state";
 import { Flex } from "components/flex";
+import { Slider } from "@mantine/core";
 
 interface TrackCardProps {
     track: TrackRecord;
 }
 
 const iconMarginRight = minorScale(2);
+const maxVolume = 12;
+const minVolume = -12;
 const width = majorScale(21);
 
 const TrackCard: React.FC<TrackCardProps> = (props: TrackCardProps) => {
     const { track } = props;
-    const { id, name, mute, solo, instrument_id, index } = track;
+    const { id, name, mute, solo, instrument_id, index, volume } = track;
     const { state: workstationState } = useWorkstationState();
     const { update, remove, state: tracks } = useTracksState();
     const {
@@ -64,7 +67,10 @@ const TrackCard: React.FC<TrackCardProps> = (props: TrackCardProps) => {
         [files, instrument]
     );
 
-    const theme = useTheme();
+    const [localVolume, setLocalVolume] = useState<number>(volume);
+    useEffect(() => setLocalVolume(volume), [volume]);
+
+    const { colors } = useTheme();
 
     const setName = useCallback(
         (value: string) => update(id, (prev) => prev.merge({ name: value })),
@@ -78,6 +84,12 @@ const TrackCard: React.FC<TrackCardProps> = (props: TrackCardProps) => {
 
     const toggleSolo = useCallback(
         () => update(id, (prev) => prev.merge({ solo: !prev.solo })),
+        [id, update]
+    );
+
+    const handleVolumeChangeEnd = useCallback(
+        (updatedVolume: number) =>
+            update(id, (prev) => prev.merge({ volume: updatedVolume })),
         [id, update]
     );
 
@@ -115,7 +127,7 @@ const TrackCard: React.FC<TrackCardProps> = (props: TrackCardProps) => {
                         {...provided.draggableProps}>
                         <Card
                             alignItems="flex-start"
-                            background={theme.colors.gray200}
+                            background={colors.gray200}
                             className={cardClass}
                             display="flex"
                             flexDirection="column"
@@ -154,7 +166,7 @@ const TrackCard: React.FC<TrackCardProps> = (props: TrackCardProps) => {
                                 onChange={setName}
                                 value={name}
                             />
-                            <Flex.Row>
+                            <Flex.Row alignItems="center">
                                 <Tooltip content="Mute Track">
                                     <IconButton
                                         icon={
@@ -173,6 +185,18 @@ const TrackCard: React.FC<TrackCardProps> = (props: TrackCardProps) => {
                                         onClick={toggleSolo}
                                     />
                                 </Tooltip>
+                                <Pane width={majorScale(8)}>
+                                    <Slider
+                                        defaultValue={0}
+                                        max={maxVolume}
+                                        min={minVolume}
+                                        onChange={setLocalVolume}
+                                        onChangeEnd={handleVolumeChangeEnd}
+                                        radius="sm"
+                                        size="sm"
+                                        value={localVolume}
+                                    />
+                                </Pane>
                             </Flex.Row>
                         </Card>
                         <DragDropContext
@@ -185,7 +209,7 @@ const TrackCard: React.FC<TrackCardProps> = (props: TrackCardProps) => {
                                     <Flex.Row
                                         border={`2px dashed ${
                                             snapshot.isDraggingOver
-                                                ? theme.colors.blue300
+                                                ? colors.blue300
                                                 : "transparent"
                                         }`}
                                         borderRadius={minorScale(1)}
@@ -222,5 +246,5 @@ const TrackCard: React.FC<TrackCardProps> = (props: TrackCardProps) => {
     );
 };
 
-export { TrackCard };
 export type { TrackCardProps };
+export { TrackCard };

--- a/src/components/tracks/track-card/track-card.tsx
+++ b/src/components/tracks/track-card/track-card.tsx
@@ -31,15 +31,13 @@ import { css, select } from "glamor";
 import { TrackTime } from "components/tracks/track-time/track-time";
 import { useWorkstationState } from "utils/hooks/use-workstation-state";
 import { Flex } from "components/flex";
-import { Slider } from "@mantine/core";
+import { Slider } from "components/mantine/slider";
 
 interface TrackCardProps {
     track: TrackRecord;
 }
 
 const iconMarginRight = minorScale(2);
-const maxVolume = 12;
-const minVolume = -12;
 const width = majorScale(21);
 
 const TrackCard: React.FC<TrackCardProps> = (props: TrackCardProps) => {
@@ -185,18 +183,12 @@ const TrackCard: React.FC<TrackCardProps> = (props: TrackCardProps) => {
                                         onClick={toggleSolo}
                                     />
                                 </Tooltip>
-                                <Pane width={majorScale(8)}>
-                                    <Slider
-                                        defaultValue={0}
-                                        max={maxVolume}
-                                        min={minVolume}
-                                        onChange={setLocalVolume}
-                                        onChangeEnd={handleVolumeChangeEnd}
-                                        radius="sm"
-                                        size="sm"
-                                        value={localVolume}
-                                    />
-                                </Pane>
+                                <Slider
+                                    label="Vol"
+                                    onChange={setLocalVolume}
+                                    onChangeEnd={handleVolumeChangeEnd}
+                                    value={localVolume}
+                                />
                             </Flex.Row>
                         </Card>
                         <DragDropContext

--- a/src/components/workstation/song-controls.tsx
+++ b/src/components/workstation/song-controls.tsx
@@ -7,8 +7,6 @@ import {
     Label,
     TextInput,
     majorScale,
-    CaretDownIcon,
-    CaretUpIcon,
     Heading,
     Tooltip,
 } from "evergreen-ui";
@@ -22,13 +20,14 @@ import { useToneAudio } from "utils/hooks/use-tone-audio";
 import { List } from "immutable";
 import { InstrumentRecord } from "models/instrument-record";
 import { FileRecord } from "models/file-record";
+import { Slider } from "components/mantine/slider";
 
 interface SongControlsProps {
     files?: List<FileRecord>;
     instruments?: List<InstrumentRecord>;
 }
 
-const marginRight = minorScale(2);
+const marginRight = majorScale(1);
 const SongControlsHeight = majorScale(9);
 
 const SongControls: React.FC<SongControlsProps> = (
@@ -90,20 +89,14 @@ const SongControls: React.FC<SongControlsProps> = (
         [setCurrentState]
     );
 
-    const setSwing = useCallback(
+    const handleSwingChange = useCallback(
         (swing: number) => setCurrentState((prev) => prev.merge({ swing })),
         [setCurrentState]
     );
 
-    const handleDecrementVolume = useCallback(
-        () =>
-            setCurrentState((prev) => prev.merge({ volume: prev.volume - 1 })),
-        [setCurrentState]
-    );
-
-    const handleIncrementVolume = useCallback(
-        () =>
-            setCurrentState((prev) => prev.merge({ volume: prev.volume + 1 })),
+    const handleVolumeChange = useCallback(
+        (updatedVolume: number) =>
+            setCurrentState((prev) => prev.merge({ volume: updatedVolume })),
         [setCurrentState]
     );
 
@@ -142,44 +135,20 @@ const SongControls: React.FC<SongControlsProps> = (
                     onChange={handleNumberChange(1, 200, setBpm)}
                     value={bpm.toString()}
                 />
-                <Label
-                    fontSize="x-small"
-                    marginRight={marginRight}
-                    textTransform="uppercase">
-                    Swing
-                </Label>
-                <TextInput
-                    marginRight={marginRight}
-                    maxWidth={majorScale(6)}
-                    onChange={handleNumberChange(0, 100, setSwing)}
-                    value={swing.toString()}
+                <Slider
+                    label="Swing"
+                    marginX={minorScale(1)}
+                    max={100}
+                    min={0}
+                    onChange={handleSwingChange}
+                    value={swing}
                 />
-                <Label
-                    fontSize="x-small"
-                    marginRight={marginRight}
-                    textTransform="uppercase">
-                    Vol
-                </Label>
-                <Label
-                    fontSize="x-small"
-                    marginRight={marginRight}
-                    width={minorScale(3)}>
-                    {volume}
-                </Label>
-                <Tooltip content="Volume Down">
-                    <IconButton
-                        icon={CaretDownIcon}
-                        marginRight={marginRight}
-                        onClick={handleDecrementVolume}
-                    />
-                </Tooltip>
-                <Tooltip content="Volume Up">
-                    <IconButton
-                        icon={CaretUpIcon}
-                        marginRight={marginRight}
-                        onClick={handleIncrementVolume}
-                    />
-                </Tooltip>
+                <Slider
+                    label="Vol"
+                    marginX={minorScale(1)}
+                    onChange={handleVolumeChange}
+                    value={volume}
+                />
             </Pane>
         </Pane>
     );


### PR DESCRIPTION
Resolves #68

- Adds `@mantine/core` (and peer dep `@mantine/hooks`) to pull in a new `Slider` component which is wired up in both the `TrackCard` and `SongControls` components
![image](https://user-images.githubusercontent.com/11774799/166079621-e4995a2e-c047-47cc-b23d-7d025e3fa9bc.png)

Would love to build one in more of an Evergreen-ish theme, but don't really have the time right now.