### PR TITLE
Keyboard shortcut documentation + abstraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
         "premigrations:up": "npm run build:migrations",
         "prepare": "husky install",
         "start": "react-scripts start",
-        "test": "react-scripts test"
+        "test": "react-scripts test",
+        "test:watch": "react-scripts test --watch"
     },
     "version": "0.0.0"
 }

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -7,20 +7,21 @@ import {
     UnorderedList,
     majorScale,
     defaultTheme,
+    Table,
 } from "evergreen-ui";
 import { Link as ReactRouterLink } from "react-router-dom";
 import rehypeSlug from "rehype-slug";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import gfm from "remark-gfm";
-import { last } from "lodash";
+import { flatMap, last } from "lodash";
 import { NormalComponents } from "react-markdown/lib/complex-types";
 import { SpecialComponents } from "react-markdown/lib/ast-to-react";
 import ReactMarkdown from "react-markdown";
-import { useMemo } from "react";
+import { ReactElement, useMemo } from "react";
 import { CopyableHeading } from "components/copyable-heading";
 import {
     mergeComponentMap,
-    omitIs,
+    omitProps,
     transformImageUri,
     transformLinkUri,
 } from "utils/markdown-utils";
@@ -42,7 +43,7 @@ const defaultComponents: MarkdownComponentMap = {
         const isHashLink = href?.includes("#") ?? false;
         return (
             <Link
-                {...omitIs(props)}
+                {...omitProps(props)}
                 is={isHashLink ? ReactRouterLink : Link}
                 target={isHashLink ? undefined : "_blank"}
                 to={isHashLink ? props.href! : undefined}
@@ -51,28 +52,28 @@ const defaultComponents: MarkdownComponentMap = {
     },
     h2: (props) => (
         <CopyableHeading
-            {...omitIs(props)}
+            {...omitProps(props)}
             marginY={majorScale(2)}
             size={700}
         />
     ),
     h3: (props) => (
         <CopyableHeading
-            {...omitIs(props)}
+            {...omitProps(props)}
             marginY={majorScale(2)}
             size={600}
         />
     ),
     h4: (props) => (
         <CopyableHeading
-            {...omitIs(props)}
+            {...omitProps(props)}
             marginY={majorScale(2)}
             size={500}
         />
     ),
     img: (props) => (
         <Image
-            {...omitIs(props)}
+            {...omitProps(props)}
             borderRadius={majorScale(1)}
             boxShadow={last(defaultTheme.shadows)}
             display="block"
@@ -80,10 +81,34 @@ const defaultComponents: MarkdownComponentMap = {
             maxWidth="100%"
         />
     ),
-    li: (props) => <ListItem {...omitIs(props, "ordered")} />,
-    p: (props) => <Paragraph {...omitIs(props)} marginBottom={majorScale(1)} />,
-    ul: (props) => <UnorderedList {...omitIs(props, "ordered")} />,
-    code: (props) => <Code {...omitIs(props, "inline")} size={300} />,
+    li: (props) => <ListItem {...omitProps(props)} />,
+    p: (props) => (
+        <Paragraph {...omitProps(props)} marginBottom={majorScale(1)} />
+    ),
+    ul: (props) => <UnorderedList {...omitProps(props)} />,
+    code: (props) => <Code {...omitProps(props)} size={300} />,
+    table: (props) => <Table {...omitProps(props)} />,
+    th: (props) => <Table.TextCell {...omitProps(props)} />,
+    tr: (props) => <Table.Row {...omitProps(props)} />,
+    tbody: (props) => <Table.Body {...omitProps(props)} />,
+    thead: (props) => {
+        // Markdown version adds an additional <tr> around the <th> list which breaks the Evergreen
+        // table format, so reach into it and grab its children
+        const children = flatMap(
+            props.children,
+            (child: ReactElement) => child.props.children
+        ) as React.ReactNode[];
+        return <Table.Head {...omitProps(props)}>{children}</Table.Head>;
+    },
+    td: (props) => (
+        <Table.TextCell
+            {...omitProps(props)}
+            textProps={{
+                size: 400,
+                whiteSpace: "break-spaces",
+            }}
+        />
+    ),
 };
 
 const Markdown: React.FC<MarkdownProps> = (props: MarkdownProps) => {
@@ -105,5 +130,5 @@ const Markdown: React.FC<MarkdownProps> = (props: MarkdownProps) => {
     );
 };
 
-export { defaultComponents, Markdown };
 export type { MarkdownProps, MarkdownComponentMap };
+export { defaultComponents, Markdown };

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -8,6 +8,7 @@ import {
     majorScale,
     defaultTheme,
     Table,
+    minorScale,
 } from "evergreen-ui";
 import { Link as ReactRouterLink } from "react-router-dom";
 import rehypeSlug from "rehype-slug";
@@ -89,7 +90,13 @@ const defaultComponents: MarkdownComponentMap = {
     code: (props) => <Code {...omitProps(props)} size={300} />,
     table: (props) => <Table {...omitProps(props)} />,
     th: (props) => <Table.TextCell {...omitProps(props)} />,
-    tr: (props) => <Table.Row {...omitProps(props)} />,
+    tr: (props) => (
+        <Table.Row
+            {...omitProps(props)}
+            height="unset"
+            minHeight={majorScale(8)}
+        />
+    ),
     tbody: (props) => <Table.Body {...omitProps(props)} />,
     thead: (props) => {
         // Markdown version adds an additional <tr> around the <th> list which breaks the Evergreen
@@ -103,6 +110,7 @@ const defaultComponents: MarkdownComponentMap = {
     td: (props) => (
         <Table.TextCell
             {...omitProps(props)}
+            padding={minorScale(3)}
             textProps={{
                 size: 400,
                 whiteSpace: "break-spaces",

--- a/src/components/sidebar/help-dialog/help-dialog-link.tsx
+++ b/src/components/sidebar/help-dialog/help-dialog-link.tsx
@@ -10,7 +10,7 @@ import {
 import { ReactMarkdownProps } from "react-markdown/lib/complex-types";
 import { Sitemap } from "sitemap";
 import { hasValues } from "utils/collection-utils";
-import { omitIs } from "utils/markdown-utils";
+import { omitProps } from "utils/markdown-utils";
 import { absolutePath, toPathCase } from "utils/route-utils";
 import { scrollToHash } from "utils/scroll-utils";
 
@@ -59,7 +59,7 @@ const HelpDialogLink: React.FC<HelpDialogLinkProps> = (
 
     return (
         <Link
-            {...omitIs(rest)}
+            {...omitProps(rest)}
             href={href}
             onClick={handleClick}
             target={isHashLink ? undefined : "_blank"}

--- a/src/components/sidebar/help-dialog/help-dialog.tsx
+++ b/src/components/sidebar/help-dialog/help-dialog.tsx
@@ -19,7 +19,7 @@ import { Link as ReactRouterLink } from "react-router-dom";
 import { Sitemap } from "sitemap";
 import { absolutePath, joinPaths, toPathCase } from "utils/route-utils";
 import { HelpDialogLink } from "components/sidebar/help-dialog/help-dialog-link";
-import { omitIs } from "utils/markdown-utils";
+import { omitProps } from "utils/markdown-utils";
 import { CopyableHeading } from "components/copyable-heading";
 import { HelpResourceTabs } from "constants/help-resource-tabs";
 import { useTheme } from "utils/hooks/use-theme";
@@ -115,7 +115,7 @@ const getComponentMap = (
     a: (props) => <HelpDialogLink {...props} setSelectedTab={setSelectedTab} />,
     h2: (props) => (
         <CopyableHeading
-            {...omitIs(props)}
+            {...omitProps(props)}
             marginY={majorScale(2)}
             selectedTab={selectedTab}
             size={700}
@@ -123,7 +123,7 @@ const getComponentMap = (
     ),
     h3: (props) => (
         <CopyableHeading
-            {...omitIs(props)}
+            {...omitProps(props)}
             marginY={majorScale(2)}
             selectedTab={selectedTab}
             size={600}
@@ -131,7 +131,7 @@ const getComponentMap = (
     ),
     h4: (props) => (
         <CopyableHeading
-            {...omitIs(props)}
+            {...omitProps(props)}
             marginY={majorScale(2)}
             selectedTab={selectedTab}
             size={500}

--- a/src/components/workstation/edit-tab.tsx
+++ b/src/components/workstation/edit-tab.tsx
@@ -8,11 +8,9 @@ import {
     SquareIcon,
 } from "evergreen-ui";
 import React, { useCallback } from "react";
-import { useHotkeys } from "react-hotkeys-hook";
 import { useClipboardState } from "utils/hooks/use-clipboard-state";
+import { useKeyboardShortcut } from "utils/hooks/use-keyboard-shortcut";
 import { useToneControls } from "utils/hooks/use-tone-controls";
-
-const shortcutKey = navigator.platform.includes("Mac") ? "⌘" : "Ctrl+";
 
 interface EditTabProps {}
 
@@ -28,7 +26,10 @@ const EditTab: React.FC<EditTabProps> = (props: EditTabProps) => {
         []
     );
 
-    useHotkeys("cmd+d, ctrl+d", duplicateSelected, [isPlaying, selectedState]);
+    const { label } = useKeyboardShortcut("ctrl+d", duplicateSelected, [
+        isPlaying,
+        selectedState,
+    ]);
 
     return (
         <React.Fragment>
@@ -42,7 +43,7 @@ const EditTab: React.FC<EditTabProps> = (props: EditTabProps) => {
                                 closePopover,
                                 duplicateSelected
                             )}
-                            secondaryText={(shortcutKey + "D") as any}>
+                            secondaryText={label}>
                             Duplicate
                         </Menu.Item>
                         <Menu.Item

--- a/src/components/workstation/edit-tab.tsx
+++ b/src/components/workstation/edit-tab.tsx
@@ -1,4 +1,5 @@
 import { Menu } from "components/menu/menu";
+import { Key } from "enums/key";
 import {
     AnnotationIcon,
     Button,
@@ -26,10 +27,11 @@ const EditTab: React.FC<EditTabProps> = (props: EditTabProps) => {
         []
     );
 
-    const { label } = useKeyboardShortcut("ctrl+d", duplicateSelected, [
-        isPlaying,
-        selectedState,
-    ]);
+    const { label } = useKeyboardShortcut(
+        `${Key.Control}+d`,
+        duplicateSelected,
+        [isPlaying, selectedState]
+    );
 
     return (
         <React.Fragment>

--- a/src/components/workstation/file-tab.tsx
+++ b/src/components/workstation/file-tab.tsx
@@ -15,6 +15,7 @@ import { ProjectSettingsDialog } from "components/workstation/project-settings-d
 import { isNotNilOrEmpty } from "utils/core-utils";
 import { ExportDialog } from "components/workstation/export-dialog";
 import { useKeyboardShortcut } from "utils/hooks/use-keyboard-shortcut";
+import { Key } from "enums/key";
 
 interface FileTabProps {}
 
@@ -128,7 +129,9 @@ const FileTab: React.FC<FileTabProps> = (props: FileTabProps) => {
         ]
     );
 
-    const { label } = useKeyboardShortcut("ctrl+s", () => handleSave()());
+    const { label } = useKeyboardShortcut(`${Key.Control}+s`, () =>
+        handleSave()()
+    );
 
     const handleRevertToSavedClick = useCallback(
         (closePopover: () => void) => () => {

--- a/src/components/workstation/file-tab.tsx
+++ b/src/components/workstation/file-tab.tsx
@@ -13,10 +13,8 @@ import { useListFiles } from "utils/hooks/domain/files/use-list-files";
 import { useDialog } from "utils/hooks/use-dialog";
 import { ProjectSettingsDialog } from "components/workstation/project-settings-dialog";
 import { isNotNilOrEmpty } from "utils/core-utils";
-import { useHotkeys } from "react-hotkeys-hook";
 import { ExportDialog } from "components/workstation/export-dialog";
-
-const shortcutKey = navigator.platform.includes("Mac") ? "⌘" : "Ctrl+";
+import { useKeyboardShortcut } from "utils/hooks/use-keyboard-shortcut";
 
 interface FileTabProps {}
 
@@ -130,14 +128,7 @@ const FileTab: React.FC<FileTabProps> = (props: FileTabProps) => {
         ]
     );
 
-    useHotkeys(
-        "cmd+s, ctrl+s",
-        (event) => {
-            event.preventDefault();
-            handleSave()();
-        },
-        [handleSave]
-    );
+    const { label } = useKeyboardShortcut("ctrl+s", () => handleSave()());
 
     const handleRevertToSavedClick = useCallback(
         (closePopover: () => void) => () => {
@@ -207,7 +198,7 @@ const FileTab: React.FC<FileTabProps> = (props: FileTabProps) => {
                         </Menu.Item>
                         <Menu.Item
                             onClick={handleSave(closePopover)}
-                            secondaryText={(shortcutKey + "S") as any}>
+                            secondaryText={label}>
                             Save
                         </Menu.Item>
                         <Menu.Item onClick={handleExportClick(closePopover)}>

--- a/src/docs/overview.md
+++ b/src/docs/overview.md
@@ -131,10 +131,8 @@ This guide will serve as high-level documentation for the various different page
 
 ## Keyboard Shortcuts
 
-beets ships with a few context keyboard shortcuts that can be used to speed up your workflow.
-
-| Key Combination | Context                                                                 | Description                                                               |
-| --------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| Ctrl/⌘ + S      | [Workstation Page](#workstation-page)                                   | Saves the project                                                         |
-| Ctrl/⌘ + D      | [Workstation Page](#workstation-page)                                   | Duplicates one or more [Track Sections](#track-section) that are selected |
-| Shift + Click   | [Workstation Page](#workstation-page) > [Track Section](#track-section) | Allows multi-selection of [Track Sections](#track-section)                |
+| Key Combination | Context                               | Description                                                                           |
+| --------------- | ------------------------------------- | ------------------------------------------------------------------------------------- |
+| Ctrl/⌘ + S      | [Workstation Page](#workstation-page) | Saves the project                                                                     |
+| Ctrl/⌘ + D      | [Workstation Page](#workstation-page) | Duplicates one or more [Track Sections](#track-section) that are selected             |
+| Shift + Click   | [Track Section](#track-section)       | Allows multi-selection of [Track Sections](#track-section) to prepare for duplication |

--- a/src/docs/overview.md
+++ b/src/docs/overview.md
@@ -21,6 +21,7 @@ This guide will serve as high-level documentation for the various different page
     -   [Volume](#volume)
     -   [Mute](#mute)
     -   [Solo](#solo)
+-   [Keyboard Shortcuts](#keyboard-shortcuts)
 
 ## Workstation page
 
@@ -127,3 +128,13 @@ This guide will serve as high-level documentation for the various different page
 -   Plays a specific [Track](#track) alone. This may be easier than muting all other [Tracks](#track) in a [Project](#project) to listen to just one part.
 
 ![Solo Track](../../public/assets/SoloTrack.png)
+
+## Keyboard Shortcuts
+
+beets ships with a few context keyboard shortcuts that can be used to speed up your workflow.
+
+| Key Combination | Context                                                                 | Description                                                               |
+| --------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Ctrl/⌘ + S      | [Workstation Page](#workstation-page)                                   | Saves the project                                                         |
+| Ctrl/⌘ + D      | [Workstation Page](#workstation-page)                                   | Duplicates one or more [Track Sections](#track-section) that are selected |
+| Shift + Click   | [Workstation Page](#workstation-page) > [Track Section](#track-section) | Allows multi-selection of [Track Sections](#track-section)                |

--- a/src/enums/key.ts
+++ b/src/enums/key.ts
@@ -1,0 +1,8 @@
+enum Key {
+    Alt = "alt",
+    Command = "command",
+    Control = "control",
+    Option = "option",
+}
+
+export { Key };

--- a/src/utils/hooks/use-clipboard-state.ts
+++ b/src/utils/hooks/use-clipboard-state.ts
@@ -48,7 +48,7 @@ const useClipboardState = (): UseClipboardStateResult => {
 
             const { track_id } = selectedState.first()!;
 
-            // Pull from current state's trackSections to ensure any changes after selection are propogated
+            // Pull from current state's trackSections to ensure any changes after selection are propagated
             const trackSections = intersectionWith(
                 selectedState,
                 state.trackSections,

--- a/src/utils/hooks/use-keyboard-shortcut.ts
+++ b/src/utils/hooks/use-keyboard-shortcut.ts
@@ -1,9 +1,5 @@
-import { castArray, drop, flatMap, intersectionWith, isEmpty } from "lodash";
 import { useHotkeys } from "react-hotkeys-hook";
-import keyMirror from "keymirror";
-import { isMacOs } from "utils/navigator-utils";
-import { hasValues } from "utils/collection-utils";
-import { capitalize } from "humanize-plus";
+import { getDisplayLabel, remapShortcuts } from "utils/keyboard-shortcut-utils";
 
 interface UseKeyboardShortcutResult {
     /**
@@ -11,36 +7,6 @@ interface UseKeyboardShortcutResult {
      */
     label: string;
 }
-
-const keys = keyMirror({
-    alt: null,
-    cmd: null,
-    command: null,
-    ctrl: null,
-    control: null,
-    option: null,
-});
-
-const keyMap = {
-    [keys.alt]: keys.option,
-    [keys.option]: keys.alt,
-    [keys.cmd]: keys.ctrl,
-    [keys.command]: keys.ctrl,
-    [keys.ctrl]: keys.cmd,
-    [keys.control]: keys.cmd,
-};
-
-const keyLabelMap = {
-    [keys.alt]: capitalize(keys.alt),
-    [keys.ctrl]: capitalize(keys.ctrl),
-    [keys.control]: capitalize(keys.ctrl),
-    [keys.cmd]: "⌘",
-    [keys.command]: "⌘",
-    [keys.option]: "⌥",
-};
-
-const nonMacKeys = [keys.alt, keys.ctrl, keys.control];
-const macOsKeys = [keys.option, keys.cmd, keys.command];
 
 /**
  * Wrapper around `useHotkeys` from `react-hotkeys-hook` to handle cross-platform key handling and
@@ -69,80 +35,5 @@ const useKeyboardShortcut = (
 
     return { label: getDisplayLabel(remappedShortcut) };
 };
-
-/**
- * Formats a sanitized keyboard shortcut string (comma-separated) based on the current OS
- * @example ["ctrl+a", "cmd+a"] on Mac -> "⌘A",
- * @example ["ctrl+a", "cmd+a"] on any other system -> "Ctrl+A"
- */
-const getDisplayLabel = (shortcut: string): string => {
-    const keys = isMacOs() ? macOsKeys : nonMacKeys;
-    let displayLabel =
-        shortcut.split(",").find((shortcut) => hasKey(shortcut, ...keys)) ??
-        shortcut;
-    Object.entries(keyLabelMap).forEach(([key, label]) => {
-        displayLabel = displayLabel.replace(key, label);
-    });
-
-    return isMacOs() ? displayLabel.replace("+", "") : displayLabel;
-};
-
-const hasKey = (shortcuts: string | string[], ...keys: string[]): boolean =>
-    hasValues(
-        intersectionWith(castArray(shortcuts), keys, (shortcut, key) =>
-            new RegExp(key).test(shortcut)
-        )
-    );
-
-/**
- * Backfills cross-platform keyboard shortcuts if not present
- * @example ["ctrl+a"] -> ["ctrl+a", "cmd+a"]
- */
-const remapShortcuts = (shortcut: string | string[]): string => {
-    const shortcuts = sanitizeKeys(
-        Array.isArray(shortcut) ? shortcut : shortcut.split(",")
-    );
-
-    Object.entries(keyMap).forEach(([leftKey, rightKey]) => {
-        if (!hasKey(shortcuts, leftKey) || hasKey(shortcuts, rightKey)) {
-            return;
-        }
-
-        const shortcutKeys = splitKeys(shortcuts, leftKey);
-        shortcuts.push(
-            ...shortcutKeys.map((shortcutKey) => `${rightKey}${shortcutKey}`)
-        );
-    });
-
-    return shortcuts.join(",");
-};
-
-/**
- * Sanitizes the keyboard shortcuts in a standard format: lowercase modifier key and uppercase
- * shortcut key without whitespace
- * @example ["ctrl + a"] -> ["ctrl+A"]
- * @example ["CMD+a"] -> ["cmd+A"],
- */
-const sanitizeKeys = (shortcuts: string[]): string[] =>
-    shortcuts
-        .map((shortcut) =>
-            shortcut
-                .toLowerCase()
-                .split("+")
-                .map((shortcutPart, index) =>
-                    index === 0
-                        ? shortcutPart.trim()
-                        : shortcutPart.toUpperCase().trim()
-                )
-                .join("+")
-                .trim()
-        )
-        .filter((shortcut) => !isEmpty(shortcut));
-
-/**
- * Splits the keyboard shortcuts by the modifier key such as `ctrl` or `cmd`
- */
-const splitKeys = (shortcuts: string[], modifierKey: string): string[] =>
-    flatMap(shortcuts, (shortcut) => drop(shortcut.split(modifierKey), 1));
 
 export { useKeyboardShortcut };

--- a/src/utils/hooks/use-keyboard-shortcut.ts
+++ b/src/utils/hooks/use-keyboard-shortcut.ts
@@ -9,7 +9,7 @@ interface UseKeyboardShortcutResult {
 }
 
 /**
- * Wrapper around `useHotkeys` from `react-hotkeys-hook` to handle cross-platform key handling and
+ * Wrapper around `useHotkeys` from `react-hotkeys-hook` to handle cross-platform key mapping and
  * generation of a display label for components
  *
  * @param shortcut Comma-separated string or array of keyboard shortcuts such as "ctrl+s,ctrl+a" or ["ctrl+s", "ctrl+a"]

--- a/src/utils/hooks/use-keyboard-shortcut.ts
+++ b/src/utils/hooks/use-keyboard-shortcut.ts
@@ -1,0 +1,148 @@
+import { castArray, drop, flatMap, intersectionWith, isEmpty } from "lodash";
+import { useHotkeys } from "react-hotkeys-hook";
+import keyMirror from "keymirror";
+import { isMacOs } from "utils/navigator-utils";
+import { hasValues } from "utils/collection-utils";
+import { capitalize } from "humanize-plus";
+
+interface UseKeyboardShortcutResult {
+    /**
+     * Formatted and OS-dependent label to display on components
+     */
+    label: string;
+}
+
+const keys = keyMirror({
+    alt: null,
+    cmd: null,
+    command: null,
+    ctrl: null,
+    control: null,
+    option: null,
+});
+
+const keyMap = {
+    [keys.alt]: keys.option,
+    [keys.option]: keys.alt,
+    [keys.cmd]: keys.ctrl,
+    [keys.command]: keys.ctrl,
+    [keys.ctrl]: keys.cmd,
+    [keys.control]: keys.cmd,
+};
+
+const keyLabelMap = {
+    [keys.alt]: capitalize(keys.alt),
+    [keys.ctrl]: capitalize(keys.ctrl),
+    [keys.control]: capitalize(keys.ctrl),
+    [keys.cmd]: "⌘",
+    [keys.command]: "⌘",
+    [keys.option]: "⌥",
+};
+
+const nonMacKeys = [keys.alt, keys.ctrl, keys.control];
+const macOsKeys = [keys.option, keys.cmd, keys.command];
+
+/**
+ * Wrapper around `useHotkeys` from `react-hotkeys-hook` to handle cross-platform key handling and
+ * generation of a display label for components
+ *
+ * @param shortcut Comma-separated string or array of keyboard shortcuts such as "ctrl+s,ctrl+a" or ["ctrl+s", "ctrl+a"]
+ * Note: Modifier keys (i.e. ctrl or cmd) only need to be specified once - the hook will handle
+ * duplicating the shortcuts for the other OS
+ * @param callback Callback to be executed when the keyboard shortcut is activated
+ * @param dependencies Optional dependencies that the callback function needs to run properly
+ */
+const useKeyboardShortcut = (
+    shortcut: string | string[],
+    callback: (event: KeyboardEvent) => void,
+    dependencies?: any[]
+): UseKeyboardShortcutResult => {
+    const remappedShortcut = remapShortcuts(shortcut);
+    useHotkeys(
+        remappedShortcut,
+        (event) => {
+            event.preventDefault();
+            callback(event);
+        },
+        dependencies
+    );
+
+    return { label: getDisplayLabel(remappedShortcut) };
+};
+
+/**
+ * Formats a sanitized keyboard shortcut string (comma-separated) based on the current OS
+ * @example ["ctrl+a", "cmd+a"] on Mac -> "⌘A",
+ * @example ["ctrl+a", "cmd+a"] on any other system -> "Ctrl+A"
+ */
+const getDisplayLabel = (shortcut: string): string => {
+    const keys = isMacOs() ? macOsKeys : nonMacKeys;
+    let displayLabel =
+        shortcut.split(",").find((shortcut) => hasKey(shortcut, ...keys)) ??
+        shortcut;
+    Object.entries(keyLabelMap).forEach(([key, label]) => {
+        displayLabel = displayLabel.replace(key, label);
+    });
+
+    return isMacOs() ? displayLabel.replace("+", "") : displayLabel;
+};
+
+const hasKey = (shortcuts: string | string[], ...keys: string[]): boolean =>
+    hasValues(
+        intersectionWith(castArray(shortcuts), keys, (shortcut, key) =>
+            new RegExp(key).test(shortcut)
+        )
+    );
+
+/**
+ * Backfills cross-platform keyboard shortcuts if not present
+ * @example ["ctrl+a"] -> ["ctrl+a", "cmd+a"]
+ */
+const remapShortcuts = (shortcut: string | string[]): string => {
+    const shortcuts = sanitizeKeys(
+        Array.isArray(shortcut) ? shortcut : shortcut.split(",")
+    );
+
+    Object.entries(keyMap).forEach(([leftKey, rightKey]) => {
+        if (!hasKey(shortcuts, leftKey) || hasKey(shortcuts, rightKey)) {
+            return;
+        }
+
+        const shortcutKeys = splitKeys(shortcuts, leftKey);
+        shortcuts.push(
+            ...shortcutKeys.map((shortcutKey) => `${rightKey}${shortcutKey}`)
+        );
+    });
+
+    return shortcuts.join(",");
+};
+
+/**
+ * Sanitizes the keyboard shortcuts in a standard format: lowercase modifier key and uppercase
+ * shortcut key without whitespace
+ * @example ["ctrl + a"] -> ["ctrl+A"]
+ * @example ["CMD+a"] -> ["cmd+A"],
+ */
+const sanitizeKeys = (shortcuts: string[]): string[] =>
+    shortcuts
+        .map((shortcut) =>
+            shortcut
+                .toLowerCase()
+                .split("+")
+                .map((shortcutPart, index) =>
+                    index === 0
+                        ? shortcutPart.trim()
+                        : shortcutPart.toUpperCase().trim()
+                )
+                .join("+")
+                .trim()
+        )
+        .filter((shortcut) => !isEmpty(shortcut));
+
+/**
+ * Splits the keyboard shortcuts by the modifier key such as `ctrl` or `cmd`
+ */
+const splitKeys = (shortcuts: string[], modifierKey: string): string[] =>
+    flatMap(shortcuts, (shortcut) => drop(shortcut.split(modifierKey), 1));
+
+export { useKeyboardShortcut };

--- a/src/utils/keyboard-shortcut-utils.test.ts
+++ b/src/utils/keyboard-shortcut-utils.test.ts
@@ -1,0 +1,116 @@
+import { castArray } from "lodash";
+import {
+    getDisplayLabel,
+    hasKey,
+    remapShortcuts,
+    sanitizeKeys,
+    splitKeys,
+} from "utils/keyboard-shortcut-utils";
+import * as navigatorUtils from "./navigator-utils";
+
+describe("KeyboardShortcutUtils", () => {
+    describe("getDisplayLabel", () => {
+        test.each`
+            shortcut          | isMacOs  | expected
+            ${"ctrl+a"}       | ${true}  | ${"⌘A"}
+            ${"CTRL+A"}       | ${true}  | ${"⌘A"}
+            ${"ctrl+a,cmd+a"} | ${true}  | ${"⌘A"}
+            ${"ctrl+a"}       | ${false} | ${"Ctrl+A"}
+            ${"cmd+a"}        | ${false} | ${"Ctrl+A"}
+            ${"CmD  +  a"}    | ${false} | ${"Ctrl+A"}
+        `(
+            `should return '$expected' when shortcut is '$shortcut' and isMacOs is $isMacOs`,
+            ({ shortcut, isMacOs, expected }) => {
+                // Arrange
+                jest.spyOn(navigatorUtils, "isMacOs").mockReturnValue(isMacOs);
+
+                // Act
+                const result = getDisplayLabel(shortcut);
+
+                // Assert
+                expect(result).toBe(expected);
+            }
+        );
+    });
+
+    describe("hasKey", () => {
+        test.each`
+            shortcut                   | key                    | expected
+            ${"ctrl"}                  | ${["ctrl"]}            | ${true}
+            ${"ctrl+a"}                | ${["ctrl"]}            | ${true}
+            ${"CONTROL + a"}           | ${["control"]}         | ${true}
+            ${["control+a", "ctrl+a"]} | ${["control", "ctrl"]} | ${true}
+            ${["control+a", "ctrl+a"]} | ${["control"]}         | ${true}
+            ${"control+a"}             | ${["ctrl"]}            | ${false}
+            ${"cmd + a"}               | ${["control"]}         | ${false}
+            ${"a"}                     | ${["control"]}         | ${false}
+            ${"alt"}                   | ${["option"]}          | ${false}
+        `(
+            `should return '$expected' when shortcut is '$shortcut' and key is '$key'`,
+            ({ shortcut, key, expected }) => {
+                // Arrange & Act
+                const result = hasKey(shortcut, ...key);
+
+                // Assert
+                expect(result).toBe(expected);
+            }
+        );
+    });
+
+    describe("remapShortcuts", () => {
+        test.each`
+            shortcuts                       | expected
+            ${["ctrl+a", "ctrl+d"]}         | ${["ctrl+A", "ctrl+D", "cmd+A", "cmd+D"].join()}
+            ${["alt+a"]}                    | ${["alt+A", "option+A"].join()}
+            ${["cmd+a"]}                    | ${["cmd+A", "ctrl+A"].join()}
+            ${["cmd+a", "ctrl+a"]}          | ${["cmd+A", "ctrl+A"].join()}
+            ${["cmd+a", "ctrl+a", "cmd+a"]} | ${["cmd+A", "ctrl+A"].join()}
+        `(
+            `should return '$expected' when shortcuts is '$shortcuts'`,
+            ({ shortcuts, expected }) => {
+                // Arrange & Act
+                const result = remapShortcuts(shortcuts);
+
+                // Assert
+                expect(result).toStrictEqual(expected);
+            }
+        );
+    });
+
+    describe("sanitizeKeys", () => {
+        test.each`
+            shortcuts                     | expected
+            ${["ctrl+a", "ctrl+d"]}       | ${["ctrl+A", "ctrl+D"]}
+            ${["ctrl + a", "ctrl +   D"]} | ${["ctrl+A", "ctrl+D"]}
+            ${["CMD + a", "COMMAND + c"]} | ${["cmd+A", "command+C"]}
+            ${["ctrl + a + b"]}           | ${["ctrl+A+B"]}
+        `(
+            `should return '$expected' when shortcuts is '$shortcuts'`,
+            ({ shortcuts, expected }) => {
+                // Arrange & Act
+                const result = sanitizeKeys(shortcuts);
+
+                // Assert
+                expect(result).toStrictEqual(expected);
+            }
+        );
+    });
+
+    describe("splitKeys", () => {
+        test.each`
+            shortcuts                     | modifierKey | expected
+            ${["ctrl+a", "ctrl+d"]}       | ${"ctrl"}   | ${["+a", "+d"]}
+            ${["ctrl + a", "ctrl +   D"]} | ${"ctrl"}   | ${[" + a", " +   D"]}
+            ${["ctrl + a", "cmd + c"]}    | ${"ctrl"}   | ${[" + a"]}
+        `(
+            `should return '$expected' when shortcuts is '$shortcuts' and modifierKey is '$modifierKey'`,
+            ({ shortcuts, modifierKey, expected }) => {
+                // Arrange & Act
+                const result = splitKeys(shortcuts, modifierKey);
+
+                // Assert
+                expect(result).toStrictEqual(expected);
+            }
+        );
+    });
+});

--- a/src/utils/keyboard-shortcut-utils.ts
+++ b/src/utils/keyboard-shortcut-utils.ts
@@ -1,0 +1,121 @@
+import keyMirror from "keymirror";
+import {
+    capitalize,
+    castArray,
+    drop,
+    flatMap,
+    intersectionWith,
+    isEmpty,
+    uniq,
+} from "lodash";
+import { hasValues } from "utils/collection-utils";
+import { isMacOs } from "utils/navigator-utils";
+
+const keys = keyMirror({
+    alt: null,
+    cmd: null,
+    command: null,
+    ctrl: null,
+    control: null,
+    option: null,
+});
+
+const keyMap = {
+    [keys.alt]: keys.option,
+    [keys.option]: keys.alt,
+    [keys.cmd]: keys.ctrl,
+    [keys.command]: keys.ctrl,
+    [keys.ctrl]: keys.cmd,
+    [keys.control]: keys.cmd,
+};
+
+const keyLabelMap = {
+    [keys.alt]: capitalize(keys.alt),
+    [keys.ctrl]: capitalize(keys.ctrl),
+    [keys.control]: capitalize(keys.ctrl),
+    [keys.cmd]: "⌘",
+    [keys.command]: "⌘",
+    [keys.option]: "⌥",
+};
+
+const nonMacKeys = [keys.alt, keys.ctrl, keys.control];
+const macOsKeys = [keys.option, keys.cmd, keys.command];
+
+/**
+ * Formats a sanitized keyboard shortcut string (comma-separated) based on the current OS
+ * @example ["ctrl+a", "cmd+a"] on Mac -> "⌘A",
+ * @example ["ctrl+a", "cmd+a"] on any other system -> "Ctrl+A"
+ */
+const getDisplayLabel = (shortcut: string): string => {
+    shortcut = remapShortcuts(shortcut);
+
+    const keys = isMacOs() ? macOsKeys : nonMacKeys;
+    let displayLabel =
+        shortcut.split(",").find((shortcut) => hasKey(shortcut, ...keys)) ??
+        shortcut;
+    Object.entries(keyLabelMap).forEach(([key, label]) => {
+        displayLabel = displayLabel.replace(key, label);
+    });
+
+    return isMacOs() ? displayLabel.replace("+", "") : displayLabel;
+};
+
+const hasKey = (shortcuts: string | string[], ...keys: string[]): boolean =>
+    hasValues(
+        intersectionWith(castArray(shortcuts), keys, (shortcut, key) =>
+            new RegExp(key, "i").test(shortcut)
+        )
+    );
+
+/**
+ * Backfills cross-platform keyboard shortcuts if not present
+ * @example ["ctrl+a"] -> ["ctrl+a", "cmd+a"]
+ */
+const remapShortcuts = (shortcut: string | string[]): string => {
+    const shortcuts = sanitizeKeys(
+        Array.isArray(shortcut) ? shortcut : shortcut.split(",")
+    );
+
+    Object.entries(keyMap).forEach(([leftKey, rightKey]) => {
+        if (!hasKey(shortcuts, leftKey) || hasKey(shortcuts, rightKey)) {
+            return;
+        }
+
+        const shortcutKeys = splitKeys(shortcuts, leftKey);
+        shortcuts.push(
+            ...shortcutKeys.map((shortcutKey) => `${rightKey}${shortcutKey}`)
+        );
+    });
+
+    return uniq(shortcuts).join(",");
+};
+
+/**
+ * Sanitizes the keyboard shortcuts in a standard format: lowercase modifier key and uppercase
+ * shortcut key without whitespace
+ * @example ["ctrl + a"] -> ["ctrl+A"]
+ * @example ["CMD+a"] -> ["cmd+A"],
+ */
+const sanitizeKeys = (shortcuts: string[]): string[] =>
+    shortcuts
+        .map((shortcut) =>
+            shortcut
+                .toLowerCase()
+                .split("+")
+                .map((shortcutPart, index) =>
+                    index === 0
+                        ? shortcutPart.trim()
+                        : shortcutPart.toUpperCase().trim()
+                )
+                .join("+")
+                .trim()
+        )
+        .filter((shortcut) => !isEmpty(shortcut));
+
+/**
+ * Splits the keyboard shortcuts by the modifier key such as `ctrl` or `cmd`
+ */
+const splitKeys = (shortcuts: string[], modifierKey: string): string[] =>
+    flatMap(shortcuts, (shortcut) => drop(shortcut.split(modifierKey), 1));
+
+export { getDisplayLabel, hasKey, remapShortcuts, sanitizeKeys, splitKeys };

--- a/src/utils/markdown-utils.ts
+++ b/src/utils/markdown-utils.ts
@@ -6,10 +6,22 @@ const mergeComponentMap = (
     componentMap: MarkdownComponentMap
 ): MarkdownComponentMap => merge({}, defaultComponents, componentMap);
 
-const omitIs = <T extends { is?: string | undefined }>(
+/**
+ * Omits 'is' and other unnecessary props added by react-markdown that may conflict or cause React warnings
+ */
+const omitProps = <T extends { is?: string | undefined }>(
     props: T,
     ...additionalKeys: Array<keyof T>
-) => omit(props, "is", ...additionalKeys);
+) =>
+    omit(
+        props,
+        "is",
+        "node",
+        "isHeader",
+        "inline",
+        "ordered",
+        ...additionalKeys
+    );
 
 const transformImageUri: TransformImage = (src: string) =>
     src.replace("../../public", "");
@@ -17,4 +29,4 @@ const transformImageUri: TransformImage = (src: string) =>
 const transformLinkUri: TransformLink = (href: string) =>
     href.replace("./", "../");
 
-export { mergeComponentMap, omitIs, transformImageUri, transformLinkUri };
+export { mergeComponentMap, omitProps, transformImageUri, transformLinkUri };

--- a/src/utils/navigator-utils.ts
+++ b/src/utils/navigator-utils.ts
@@ -1,0 +1,3 @@
+const isMacOs = () => navigator.platform.includes("Mac");
+
+export { isMacOs };


### PR DESCRIPTION
- Adds a new table in the Overview section of the documentation with current keyboard shortcuts
![image](https://user-images.githubusercontent.com/11774799/166167267-4968fa7f-6a43-47b2-b359-335505d6bab9.png)
- Abstracts a wrapper hook around `useHotkeys` that handles porting over key combinations to or from Mac/Windows/Linux, as well as creation of a display label