### PR TITLE
Add tests + rewrite diffUpdatedEntities function with documentation

### DIFF
--- a/src/utils/collection-utils.test.ts
+++ b/src/utils/collection-utils.test.ts
@@ -2,7 +2,8 @@ import { List, Range } from "immutable";
 import { random } from "lodash";
 import { TrackRecord } from "models/track-record";
 import { TrackSectionRecord } from "models/track-section-record";
-import { generateId } from "utils/id-utils";
+import { getCurrentTime } from "utils/date-utils";
+
 import { diffUpdatedEntities, groupBy } from "./collection-utils";
 
 describe("CollectionUtils", () => {
@@ -46,7 +47,7 @@ describe("CollectionUtils", () => {
         it("should not return record that is unmodified", () => {
             // Arrange
             const unexpected = new TrackRecord().merge({
-                created_on: generateId(),
+                created_on: getCurrentTime(),
             });
             const values = List.of(unexpected);
             const initialValues = List.of(unexpected);
@@ -61,7 +62,7 @@ describe("CollectionUtils", () => {
         it("should return record that is modified from initial collection", () => {
             // Arrange
             const initialRecord = new TrackRecord().merge({
-                created_on: generateId(),
+                created_on: getCurrentTime(),
                 name: "Initial",
             });
             const updatedRecord = initialRecord.merge({ name: "Updated" });
@@ -80,7 +81,7 @@ describe("CollectionUtils", () => {
         it("should return record that is modified from initial collection when order is different", () => {
             // Arrange
             const initialRecord = new TrackRecord().merge({
-                created_on: generateId(),
+                created_on: getCurrentTime(),
                 name: "Initial",
             });
             const unexpected = new TrackRecord();

--- a/src/utils/collection-utils.test.ts
+++ b/src/utils/collection-utils.test.ts
@@ -3,7 +3,6 @@ import { random } from "lodash";
 import { TrackRecord } from "models/track-record";
 import { TrackSectionRecord } from "models/track-section-record";
 import { getCurrentTime } from "utils/date-utils";
-
 import { diffUpdatedEntities, groupBy } from "./collection-utils";
 
 describe("CollectionUtils", () => {

--- a/src/utils/collection-utils.test.ts
+++ b/src/utils/collection-utils.test.ts
@@ -2,38 +2,140 @@ import { List, Range } from "immutable";
 import { random } from "lodash";
 import { TrackRecord } from "models/track-record";
 import { TrackSectionRecord } from "models/track-section-record";
-import { groupBy } from "./collection-utils";
+import { generateId } from "utils/id-utils";
+import { diffUpdatedEntities, groupBy } from "./collection-utils";
 
 describe("CollectionUtils", () => {
+    describe("diffUpdatedEntities", () => {
+        it("should return left-side record when record is not persisted", () => {
+            // Arrange
+            const expected = new TrackRecord().merge({
+                created_on: undefined,
+            });
+            const values = List.of(expected);
+            const initialValues = List.of(expected);
+
+            // Act
+            const result = diffUpdatedEntities(values, initialValues);
+
+            // Assert
+            expect(
+                result.find((record) => record.equals(expected))
+            ).not.toBeNil();
+        });
+
+        it("should return left-side POJO when not persisted", () => {
+            // Arrange
+            const expected = new TrackRecord()
+                .merge({
+                    created_on: undefined,
+                })
+                .toPOJO();
+            const values = List.of(expected);
+            const initialValues = List.of(expected);
+
+            // Act
+            const result = diffUpdatedEntities(values, initialValues);
+
+            // Assert
+            expect(
+                result.find((record) => record.id === expected.id)
+            ).not.toBeNil();
+        });
+
+        it("should not return record that is unmodified", () => {
+            // Arrange
+            const unexpected = new TrackRecord().merge({
+                created_on: generateId(),
+            });
+            const values = List.of(unexpected);
+            const initialValues = List.of(unexpected);
+
+            // Act
+            const result = diffUpdatedEntities(values, initialValues);
+
+            // Assert
+            expect(result).toBeEmpty();
+        });
+
+        it("should return record that is modified from initial collection", () => {
+            // Arrange
+            const initialRecord = new TrackRecord().merge({
+                created_on: generateId(),
+                name: "Initial",
+            });
+            const updatedRecord = initialRecord.merge({ name: "Updated" });
+            const values = List.of(initialRecord);
+            const initialValues = List.of(updatedRecord);
+
+            // Act
+            const result = diffUpdatedEntities(values, initialValues);
+
+            // Assert
+            expect(
+                result.find((record) => record.id === initialRecord.id)
+            ).not.toBeNil();
+        });
+
+        it("should return record that is modified from initial collection when order is different", () => {
+            // Arrange
+            const initialRecord = new TrackRecord().merge({
+                created_on: generateId(),
+                name: "Initial",
+            });
+            const unexpected = new TrackRecord();
+            const updatedRecord = initialRecord.merge({ name: "Updated" });
+            const values = List.of(unexpected, initialRecord);
+            const initialValues = List.of(updatedRecord, unexpected);
+
+            // Act
+            const result = diffUpdatedEntities(values, initialValues);
+
+            // Assert
+            expect(
+                result.find((record) => record.id === initialRecord.id)
+            ).not.toBeNil();
+        });
+    });
+
     describe("groupBy", () => {
         const matchById = (left: TrackRecord, right: TrackRecord): boolean =>
             left.id === right.id;
 
         it("given object exists in left collection but not right, object is not returned", () => {
+            // Arrange
             const left = List.of(new TrackRecord());
             const right = List<TrackRecord>();
 
+            // Act
             const result = groupBy(left, right, matchById);
 
+            // Assert
             expect(result).toBeEmpty();
         });
 
         it("given object exists in right collection but not left, object is not returned", () => {
+            // Arrange
             const left = List<TrackRecord>();
             const right = List.of(new TrackRecord());
 
+            // Act
             const result = groupBy(left, right, matchById);
 
+            // Assert
             expect(result).toBeEmpty();
         });
 
         it("given object exists in both collections, object is returned", () => {
+            // Arrange
             const object = new TrackRecord();
             const left = List.of(object);
             const right = List.of(object);
 
+            // Act
             const result = groupBy(left, right, matchById);
 
+            // Assert
             expect(result).not.toBeEmpty();
             const grouping = result.first()!;
             expect(grouping.left).toBe(object);
@@ -41,6 +143,7 @@ describe("CollectionUtils", () => {
         });
 
         it("given object exists in both collections but is in different order, object is returned", () => {
+            // Arrange
             const objects = Range(0, 10)
                 .map(() => new TrackRecord())
                 .toList();
@@ -51,12 +154,14 @@ describe("CollectionUtils", () => {
                 )
             ).sort(() => random(-1, 1, false));
 
+            // Act
             const result = groupBy(
                 left,
                 right,
                 (left, right) => left.id === right.track_id
             );
 
+            // Assert
             expect(result).not.toBeEmpty();
             expect(result.count()).toBe(left.count());
             left.forEach((left) => {

--- a/src/utils/collection-utils.ts
+++ b/src/utils/collection-utils.ts
@@ -4,7 +4,7 @@ import { OrderableEntity } from "interfaces/orderable-entity";
 import _ from "lodash";
 import { Grouping } from "types/grouping";
 import { isPersisted } from "utils/auditable-utils";
-import { isEqual, isNilOrEmpty, isNotNilOrEmpty } from "utils/core-utils";
+import { isEqual, isNilOrEmpty } from "utils/core-utils";
 
 const diffDeletedEntities = <T extends Auditable>(
     initialValues: List<T>,
@@ -28,16 +28,20 @@ const diffUpdatedEntities = <T extends Auditable>(
     initialValues: List<T>
 ): List<T> => {
     const createdOrUpdated = values.filter((value) => {
-        // Find initial value by strict equality check - if a matching initialValue is found,
+        if (!isPersisted(value)) {
+            return true;
+        }
+
+        // Find initial value by deep equality check - if a matching initialValue is found,
         // it means the entity is unchanged and shouldn't be returned
         const initialValue = initialValues.find((initialValue) =>
             isEqual(value, initialValue)
         );
 
-        return !isPersisted(value) || initialValue == null;
+        return initialValue == null;
     });
 
-    return createdOrUpdated.filter(isNotNilOrEmpty);
+    return createdOrUpdated;
 };
 
 /**

--- a/src/utils/collection-utils.ts
+++ b/src/utils/collection-utils.ts
@@ -4,7 +4,7 @@ import { OrderableEntity } from "interfaces/orderable-entity";
 import _ from "lodash";
 import { Grouping } from "types/grouping";
 import { isPersisted } from "utils/auditable-utils";
-import { isNilOrEmpty } from "utils/core-utils";
+import { isEqual, isNilOrEmpty, isNotNilOrEmpty } from "utils/core-utils";
 
 const diffDeletedEntities = <T extends Auditable>(
     initialValues: List<T>,
@@ -19,21 +19,26 @@ const diffDeletedEntities = <T extends Auditable>(
         ).filter(isPersisted)
     );
 
+/**
+ * Returns a list of entities that either do not exist in the initial list, are not persisted,
+ * or have changed from their initial value
+ */
 const diffUpdatedEntities = <T extends Auditable>(
     values: List<T>,
     initialValues: List<T>
-): List<T> =>
-    List(
-        _.differenceWith(values.toArray(), initialValues.toArray(), (a, b) => {
-            const isDifferent =
-                Record.isRecord(a) && Record.isRecord(b) && !a.equals(b);
-            if (!isPersisted(a) || isDifferent) {
-                return false; // Returning 'false' marks it as different/updated
-            }
+): List<T> => {
+    const createdOrUpdated = values.filter((value) => {
+        // Find initial value by strict equality check - if a matching initialValue is found,
+        // it means the entity is unchanged and shouldn't be returned
+        const initialValue = initialValues.find((initialValue) =>
+            isEqual(value, initialValue)
+        );
 
-            return true;
-        })
-    );
+        return !isPersisted(value) || initialValue == null;
+    });
+
+    return createdOrUpdated.filter(isNotNilOrEmpty);
+};
 
 /**
  * Groups two collections of entities by the provided comparator. For sorting purposes, the left

--- a/src/utils/date-utils.ts
+++ b/src/utils/date-utils.ts
@@ -1,7 +1,7 @@
 import { DateTime } from "luxon";
 import { isNilOrEmpty } from "utils/collection-utils";
 
-const formatNow = (): string => formatUpdatedOn(new Date().toISOString());
+const getCurrentTime = () => new Date().toISOString();
 
 const formatUpdatedOn = (updated_on?: string): string =>
     isNilOrEmpty(updated_on)
@@ -10,4 +10,4 @@ const formatUpdatedOn = (updated_on?: string): string =>
               DateTime.DATETIME_MED_WITH_WEEKDAY
           );
 
-export { formatNow, formatUpdatedOn };
+export { getCurrentTime, formatUpdatedOn };


### PR DESCRIPTION
This refactor was originally written when I was debugging the saving issues (#210), but I think it's easier to understand + has test coverage now, so it should come along.