### PR TITLE
Add eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,57 @@
+module.exports = {
+    extends: ["plugin:collation/strict"],
+    parser: "@typescript-eslint/parser",
+    parserOptions: {
+        ecmaFeatures: {
+            jsx: true,
+        },
+        project: "./tsconfig.json",
+    },
+    plugins: ["@typescript-eslint", "collation", "typescript-sort-keys"],
+    rules: {
+        "@typescript-eslint/consistent-type-definitions": "error",
+        "@typescript-eslint/consistent-type-exports": "off", // TODO: Set this to `error` when cra is updated
+        "@typescript-eslint/consistent-type-imports": "off", // TODO: Set this to `error` when cra is updated
+        "collation/no-inline-export": "off", // TODO: Set this to `error` when cra is updated (used in conjunction with consistent-type-exports/imports)
+        "@typescript-eslint/sort-type-union-intersection-members": "error",
+        "@typescript-eslint/strict-boolean-expressions": "warn",
+        curly: "error",
+        eqeqeq: [
+            "error",
+            "always",
+            {
+                null: "ignore",
+            },
+        ],
+        "padding-line-between-statements": "off",
+        "@typescript-eslint/padding-line-between-statements": [
+            "error",
+            {
+                blankLine: "always",
+                prev: "*",
+                next: "export",
+            },
+            {
+                blankLine: "never",
+                prev: "export",
+                next: "export",
+            },
+            {
+                blankLine: "always",
+                prev: "import",
+                next: "*",
+            },
+            {
+                blankLine: "never",
+                prev: "import",
+                next: "import",
+            },
+        ],
+        "typescript-sort-keys/interface": [
+            "error",
+            "asc",
+            { caseSensitive: false },
+        ],
+        "typescript-sort-keys/string-enum": "error",
+    },
+};

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,11 +42,14 @@ jobs:
             - name: npm install
               run: npm install
 
-            - name: npm run build
-              run: npm run build
+            - name: npm run format:check
+              run: npm run format:check
 
             - name: npm run lint
               run: npm run lint
+
+            - name: npm run build
+              run: npm run build
 
             - name: npm run test
               run: npm run test -- --verbose

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,11 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 . "$(dirname "$0")/_/husky.sh"
 
-ALL_CHANGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -e '\.ts' -e '\.tsx' -e '\.json' -e '\.md' | sed 's| |\\ |g')
-TS_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -e '\.ts' -e '\.tsx' | sed 's| |\\ |g')
-
-[[ ! -z  "$TS_FILES" ]] && npx collation --files $TS_FILES
-[[ ! -z  "$ALL_CHANGED_FILES" ]] && npx prettier $ALL_CHANGED_FILES --write
-[[ ! -z  "$ALL_CHANGED_FILES" ]] && git add $ALL_CHANGED_FILES
-
-exit 0
+npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,11 +58,15 @@
                 "@types/react-dom": "18.0.1",
                 "@types/react-router-dom": "5.3.3",
                 "@types/uuid": "8.3.1",
+                "@typescript-eslint/eslint-plugin": "5.27.1",
+                "@typescript-eslint/parser": "5.27.1",
                 "chalk": "4.1.2",
-                "collation": "0.9.0",
                 "dotenv": "10.0.0",
+                "eslint-plugin-collation": "1.0.2",
+                "eslint-plugin-typescript-sort-keys": "2.1.0",
                 "husky": "7.0.4",
                 "jest-extended": "1.2.1",
+                "lint-staged": "^13.0.1",
                 "node-pg-migrate": "6.0.0",
                 "openapi-typescript": "4.4.0",
                 "pluralize": "8.0.0",
@@ -4258,28 +4262,31 @@
             "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw=="
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "4.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.1.tgz",
-            "integrity": "sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==",
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.27.1.tgz",
+            "integrity": "sha512-6dM5NKT57ZduNnJfpY81Phe9nc9wolnMCnknb1im6brWi1RYv84nbMS3olJa27B6+irUVV1X/Wb+Am0FjJdGFw==",
+            "dev": true,
             "dependencies": {
-                "@typescript-eslint/experimental-utils": "4.29.1",
-                "@typescript-eslint/scope-manager": "4.29.1",
-                "debug": "^4.3.1",
+                "@typescript-eslint/scope-manager": "5.27.1",
+                "@typescript-eslint/type-utils": "5.27.1",
+                "@typescript-eslint/utils": "5.27.1",
+                "debug": "^4.3.4",
                 "functional-red-black-tree": "^1.0.1",
-                "regexpp": "^3.1.0",
-                "semver": "^7.3.5",
+                "ignore": "^5.2.0",
+                "regexpp": "^3.2.0",
+                "semver": "^7.3.7",
                 "tsutils": "^3.21.0"
             },
             "engines": {
-                "node": "^10.12.0 || >=12.0.0"
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^4.0.0",
-                "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+                "@typescript-eslint/parser": "^5.0.0",
+                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -4287,10 +4294,76 @@
                 }
             }
         },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+            "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.27.1",
+                "@typescript-eslint/visitor-keys": "5.27.1"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+            "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+            "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.27.1",
+                "eslint-visitor-keys": "^3.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-visitor-keys": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 4"
+            }
+        },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+            "version": "7.3.7",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -4302,14 +4375,14 @@
             }
         },
         "node_modules/@typescript-eslint/experimental-utils": {
-            "version": "4.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.1.tgz",
-            "integrity": "sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==",
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
+            "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
             "dependencies": {
                 "@types/json-schema": "^7.0.7",
-                "@typescript-eslint/scope-manager": "4.29.1",
-                "@typescript-eslint/types": "4.29.1",
-                "@typescript-eslint/typescript-estree": "4.29.1",
+                "@typescript-eslint/scope-manager": "4.33.0",
+                "@typescript-eslint/types": "4.33.0",
+                "@typescript-eslint/typescript-estree": "4.33.0",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0"
             },
@@ -4325,24 +4398,25 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "4.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.1.tgz",
-            "integrity": "sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==",
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.27.1.tgz",
+            "integrity": "sha512-7Va2ZOkHi5NP+AZwb5ReLgNF6nWLGTeUJfxdkVUAPPSaAdbWNnFZzLZ4EGGmmiCTg+AwlbE1KyUYTBglosSLHQ==",
+            "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "4.29.1",
-                "@typescript-eslint/types": "4.29.1",
-                "@typescript-eslint/typescript-estree": "4.29.1",
-                "debug": "^4.3.1"
+                "@typescript-eslint/scope-manager": "5.27.1",
+                "@typescript-eslint/types": "5.27.1",
+                "@typescript-eslint/typescript-estree": "5.27.1",
+                "debug": "^4.3.4"
             },
             "engines": {
-                "node": "^10.12.0 || >=12.0.0"
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -4350,13 +4424,111 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/scope-manager": {
-            "version": "4.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz",
-            "integrity": "sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==",
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+            "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+            "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "4.29.1",
-                "@typescript-eslint/visitor-keys": "4.29.1"
+                "@typescript-eslint/types": "5.27.1",
+                "@typescript-eslint/visitor-keys": "5.27.1"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+            "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
+            "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.27.1",
+                "@typescript-eslint/visitor-keys": "5.27.1",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "semver": "^7.3.7",
+                "tsutils": "^3.21.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+            "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.27.1",
+                "eslint-visitor-keys": "^3.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/semver": {
+            "version": "7.3.7",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@typescript-eslint/scope-manager": {
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
+            "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
+            "dependencies": {
+                "@typescript-eslint/types": "4.33.0",
+                "@typescript-eslint/visitor-keys": "4.33.0"
             },
             "engines": {
                 "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -4366,10 +4538,36 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/@typescript-eslint/type-utils": {
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.27.1.tgz",
+            "integrity": "sha512-+UC1vVUWaDHRnC2cQrCJ4QtVjpjjCgjNFpg8b03nERmkHv9JV9X5M19D7UFMd+/G7T/sgFwX2pGmWK38rqyvXw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/utils": "5.27.1",
+                "debug": "^4.3.4",
+                "tsutils": "^3.21.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "*"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@typescript-eslint/types": {
-            "version": "4.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.1.tgz",
-            "integrity": "sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==",
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
+            "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
             "engines": {
                 "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
             },
@@ -4379,12 +4577,12 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "4.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz",
-            "integrity": "sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==",
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
+            "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
             "dependencies": {
-                "@typescript-eslint/types": "4.29.1",
-                "@typescript-eslint/visitor-keys": "4.29.1",
+                "@typescript-eslint/types": "4.33.0",
+                "@typescript-eslint/visitor-keys": "4.33.0",
                 "debug": "^4.3.1",
                 "globby": "^11.0.3",
                 "is-glob": "^4.0.1",
@@ -4405,9 +4603,131 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+            "version": "7.3.7",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@typescript-eslint/utils": {
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.27.1.tgz",
+            "integrity": "sha512-mZ9WEn1ZLDaVrhRaYgzbkXBkTPghPFsup8zDbbsYTxC5OmqrFE7skkKS/sraVsLP3TcT3Ki5CSyEFBRkLH/H/w==",
+            "dev": true,
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "@typescript-eslint/scope-manager": "5.27.1",
+                "@typescript-eslint/types": "5.27.1",
+                "@typescript-eslint/typescript-estree": "5.27.1",
+                "eslint-scope": "^5.1.1",
+                "eslint-utils": "^3.0.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+            "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.27.1",
+                "@typescript-eslint/visitor-keys": "5.27.1"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+            "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
+            "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.27.1",
+                "@typescript-eslint/visitor-keys": "5.27.1",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "semver": "^7.3.7",
+                "tsutils": "^3.21.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+            "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.27.1",
+                "eslint-visitor-keys": "^3.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/eslint-visitor-keys": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/semver": {
+            "version": "7.3.7",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -4419,11 +4739,11 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "4.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz",
-            "integrity": "sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==",
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
+            "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
             "dependencies": {
-                "@typescript-eslint/types": "4.29.1",
+                "@typescript-eslint/types": "4.33.0",
                 "eslint-visitor-keys": "^2.0.0"
             },
             "engines": {
@@ -6504,6 +6824,118 @@
                 "node": ">=6"
             }
         },
+        "node_modules/cli-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+            "dev": true,
+            "dependencies": {
+                "restore-cursor": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-truncate": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
+            "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
+            "dev": true,
+            "dependencies": {
+                "slice-ansi": "^5.0.0",
+                "string-width": "^5.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-truncate/node_modules/ansi-regex": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/cli-truncate/node_modules/ansi-styles": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.1.0.tgz",
+            "integrity": "sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+            "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-truncate/node_modules/slice-ansi": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+            "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^6.0.0",
+                "is-fullwidth-code-point": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
+        "node_modules/cli-truncate/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dev": true,
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-truncate/node_modules/strip-ansi": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+            "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
         "node_modules/cliui": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -6575,134 +7007,6 @@
             "dev": true,
             "dependencies": {
                 "tslib": "2.3.1"
-            }
-        },
-        "node_modules/collation": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/collation/-/collation-0.9.0.tgz",
-            "integrity": "sha512-qqKmHKCel6RLItn7rjiJgijWgGpj7jANVLDllZV3AnmmJU1IxystKmtDtuFym8VJ1QhlAvscaLZh/Mgn47LO+Q==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "4.0.0",
-                "commander": "8.3.0",
-                "diff": "5.0.0",
-                "fuzzaldrin": "2.1.0",
-                "lodash": "4.17.21",
-                "source-map-support": "^0.5.21",
-                "ts-morph": "13.0.3"
-            },
-            "bin": {
-                "collation": "dist/collation.js"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/collation/node_modules/@ts-morph/common": {
-            "version": "0.12.3",
-            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.12.3.tgz",
-            "integrity": "sha512-4tUmeLyXJnJWvTFOKtcNJ1yh0a3SsTLi2MUoyj8iUNznFRN1ZquaNe7Oukqrnki2FzZkm0J9adCNLDZxUzvj+w==",
-            "dev": true,
-            "dependencies": {
-                "fast-glob": "^3.2.7",
-                "minimatch": "^3.0.4",
-                "mkdirp": "^1.0.4",
-                "path-browserify": "^1.0.1"
-            }
-        },
-        "node_modules/collation/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/collation/node_modules/chalk": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-            "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/collation/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/collation/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/collation/node_modules/commander": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-            "dev": true,
-            "engines": {
-                "node": ">= 12"
-            }
-        },
-        "node_modules/collation/node_modules/diff": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-            "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
-        "node_modules/collation/node_modules/mkdirp": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-            "dev": true,
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/collation/node_modules/path-browserify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-            "dev": true
-        },
-        "node_modules/collation/node_modules/ts-morph": {
-            "version": "13.0.3",
-            "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-13.0.3.tgz",
-            "integrity": "sha512-pSOfUMx8Ld/WUreoSzvMFQG5i9uEiWIsBYjpU9+TTASOeUa89j5HykomeqVULm1oqWtBdleI3KEFRLrlA3zGIw==",
-            "dev": true,
-            "dependencies": {
-                "@ts-morph/common": "~0.12.3",
-                "code-block-writer": "^11.0.0"
             }
         },
         "node_modules/collect-v8-coverage": {
@@ -6878,9 +7182,9 @@
             }
         },
         "node_modules/confusing-browser-globals": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
-            "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA=="
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
+            "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA=="
         },
         "node_modules/connect-history-api-fallback": {
             "version": "1.6.0",
@@ -7621,9 +7925,9 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -8283,6 +8587,12 @@
                 "stream-shift": "^1.0.0"
             }
         },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "dev": true
+        },
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -8688,38 +8998,6 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/eslint-config-react-app": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz",
-            "integrity": "sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==",
-            "dependencies": {
-                "confusing-browser-globals": "^1.0.10"
-            },
-            "engines": {
-                "node": "^10.12.0 || >=12.0.0"
-            },
-            "peerDependencies": {
-                "@typescript-eslint/eslint-plugin": "^4.0.0",
-                "@typescript-eslint/parser": "^4.0.0",
-                "babel-eslint": "^10.0.0",
-                "eslint": "^7.5.0",
-                "eslint-plugin-flowtype": "^5.2.0",
-                "eslint-plugin-import": "^2.22.0",
-                "eslint-plugin-jest": "^24.0.0",
-                "eslint-plugin-jsx-a11y": "^6.3.1",
-                "eslint-plugin-react": "^7.20.3",
-                "eslint-plugin-react-hooks": "^4.0.8",
-                "eslint-plugin-testing-library": "^3.9.0"
-            },
-            "peerDependenciesMeta": {
-                "eslint-plugin-jest": {
-                    "optional": true
-                },
-                "eslint-plugin-testing-library": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/eslint-import-resolver-node": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
@@ -8767,6 +9045,20 @@
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dependencies": {
                 "ms": "^2.1.1"
+            }
+        },
+        "node_modules/eslint-plugin-collation": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-collation/-/eslint-plugin-collation-1.0.2.tgz",
+            "integrity": "sha512-QIWb4VkKuXzEGPq+lIvN3GAD1S/hq5fFmm+/rHr9lRwPO+9Z7rm6lEYXeWPQaq/hI3y5x48Ra3WhbNEImAgC/Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": ">=5",
+                "@typescript-eslint/utils": ">=5",
+                "eslint": ">=6"
             }
         },
         "node_modules/eslint-plugin-flowtype": {
@@ -8907,26 +9199,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/eslint-plugin-jest": {
-            "version": "24.4.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.4.0.tgz",
-            "integrity": "sha512-8qnt/hgtZ94E9dA6viqfViKBfkJwFHXgJmTWlMGDgunw1XJEGqm3eiPjDsTanM3/u/3Az82nyQM9GX7PM/QGmg==",
-            "dependencies": {
-                "@typescript-eslint/experimental-utils": "^4.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "@typescript-eslint/eslint-plugin": ">= 4",
-                "eslint": ">=5"
-            },
-            "peerDependenciesMeta": {
-                "@typescript-eslint/eslint-plugin": {
-                    "optional": true
-                }
             }
         },
         "node_modules/eslint-plugin-jsx-a11y": {
@@ -9123,6 +9395,44 @@
             "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/eslint-plugin-typescript-sort-keys": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-typescript-sort-keys/-/eslint-plugin-typescript-sort-keys-2.1.0.tgz",
+            "integrity": "sha512-ET7ABypdz19m47QnKynzNfWPi4CTNQ5jQQC1X5d0gojIwblkbGiCa5IilsqzBTmqxZ0yXDqKBO/GBkBFQCOFsg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/experimental-utils": "^5.0.0",
+                "json-schema": "^0.4.0",
+                "natural-compare-lite": "^1.4.0"
+            },
+            "engines": {
+                "node": "10 - 12 || >= 13.9"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": "^1 || ^2 || ^3 || ^4 || ^5",
+                "eslint": "^5 || ^6 || ^7 || ^8",
+                "typescript": "^3 || ^4"
+            }
+        },
+        "node_modules/eslint-plugin-typescript-sort-keys/node_modules/@typescript-eslint/experimental-utils": {
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.27.1.tgz",
+            "integrity": "sha512-Vd8uewIixGP93sEnmTRIH6jHZYRQRkGPDPpapACMvitJKX8335VHNyqKTE+mZ+m3E2c5VznTZfSsSsS5IF7vUA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/utils": "5.27.1"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
         "node_modules/eslint-scope": {
@@ -10447,12 +10757,6 @@
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
         },
-        "node_modules/fuzzaldrin": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fuzzaldrin/-/fuzzaldrin-2.1.0.tgz",
-            "integrity": "sha1-kCBMPi/appQbso0WZF1BgGOpDps=",
-            "dev": true
-        },
         "node_modules/fuzzaldrin-plus": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/fuzzaldrin-plus/-/fuzzaldrin-plus-0.6.0.tgz",
@@ -10619,15 +10923,15 @@
             "dev": true
         },
         "node_modules/globby": {
-            "version": "11.0.4",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-            "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
             "dependencies": {
                 "array-union": "^2.1.0",
                 "dir-glob": "^3.0.1",
-                "fast-glob": "^3.1.1",
-                "ignore": "^5.1.4",
-                "merge2": "^1.3.0",
+                "fast-glob": "^3.2.9",
+                "ignore": "^5.2.0",
+                "merge2": "^1.4.1",
                 "slash": "^3.0.0"
             },
             "engines": {
@@ -10638,9 +10942,9 @@
             }
         },
         "node_modules/globby/node_modules/ignore": {
-            "version": "5.1.8",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
             "engines": {
                 "node": ">= 4"
             }
@@ -11831,9 +12135,9 @@
             }
         },
         "node_modules/is-glob": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -13263,6 +13567,12 @@
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
         },
+        "node_modules/json-schema": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+            "dev": true
+        },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -13391,10 +13701,308 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/lilconfig": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
+            "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/lines-and-columns": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
             "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+        },
+        "node_modules/lint-staged": {
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.0.1.tgz",
+            "integrity": "sha512-Ykaf4QTi0a02BF7cnq7JIPGOJxH4TkNMWhSlJdH9wOekd0X+gog47Jfh/0L31DqZe5AiydLGC7LkPqpaNm+Kvg==",
+            "dev": true,
+            "dependencies": {
+                "cli-truncate": "^3.1.0",
+                "colorette": "^2.0.17",
+                "commander": "^9.3.0",
+                "debug": "^4.3.4",
+                "execa": "^6.1.0",
+                "lilconfig": "2.0.5",
+                "listr2": "^4.0.5",
+                "micromatch": "^4.0.5",
+                "normalize-path": "^3.0.0",
+                "object-inspect": "^1.12.2",
+                "pidtree": "^0.6.0",
+                "string-argv": "^0.3.1",
+                "yaml": "^2.1.1"
+            },
+            "bin": {
+                "lint-staged": "bin/lint-staged.js"
+            },
+            "engines": {
+                "node": "^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/lint-staged"
+            }
+        },
+        "node_modules/lint-staged/node_modules/colorette": {
+            "version": "2.0.17",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.17.tgz",
+            "integrity": "sha512-hJo+3Bkn0NCHybn9Tu35fIeoOKGOk5OCC32y4Hz2It+qlCO2Q3DeQ1hRn/tDDMQKRYUEzqsl7jbF6dYKjlE60g==",
+            "dev": true
+        },
+        "node_modules/lint-staged/node_modules/commander": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz",
+            "integrity": "sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20.0 || >=14"
+            }
+        },
+        "node_modules/lint-staged/node_modules/execa": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+            "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.1",
+                "human-signals": "^3.0.1",
+                "is-stream": "^3.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^5.1.0",
+                "onetime": "^6.0.0",
+                "signal-exit": "^3.0.7",
+                "strip-final-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/lint-staged/node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lint-staged/node_modules/human-signals": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+            "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.20.0"
+            }
+        },
+        "node_modules/lint-staged/node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lint-staged/node_modules/mimic-fn": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lint-staged/node_modules/npm-run-path": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+            "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+            "dev": true,
+            "dependencies": {
+                "path-key": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lint-staged/node_modules/onetime": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "dev": true,
+            "dependencies": {
+                "mimic-fn": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lint-staged/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lint-staged/node_modules/strip-final-newline": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lint-staged/node_modules/yaml": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+            "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/listr2": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
+            "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
+            "dev": true,
+            "dependencies": {
+                "cli-truncate": "^2.1.0",
+                "colorette": "^2.0.16",
+                "log-update": "^4.0.0",
+                "p-map": "^4.0.0",
+                "rfdc": "^1.3.0",
+                "rxjs": "^7.5.5",
+                "through": "^2.3.8",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "enquirer": ">= 2.3.0 < 3"
+            },
+            "peerDependenciesMeta": {
+                "enquirer": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/listr2/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/listr2/node_modules/cli-truncate": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+            "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+            "dev": true,
+            "dependencies": {
+                "slice-ansi": "^3.0.0",
+                "string-width": "^4.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/listr2/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/listr2/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/listr2/node_modules/colorette": {
+            "version": "2.0.17",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.17.tgz",
+            "integrity": "sha512-hJo+3Bkn0NCHybn9Tu35fIeoOKGOk5OCC32y4Hz2It+qlCO2Q3DeQ1hRn/tDDMQKRYUEzqsl7jbF6dYKjlE60g==",
+            "dev": true
+        },
+        "node_modules/listr2/node_modules/slice-ansi": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+            "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/listr2/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
         },
         "node_modules/load-json-file": {
             "version": "4.0.0",
@@ -13541,6 +14149,24 @@
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
             "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
+        },
+        "node_modules/log-update": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+            "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-escapes": "^4.3.0",
+                "cli-cursor": "^3.1.0",
+                "slice-ansi": "^4.0.0",
+                "wrap-ansi": "^6.2.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/loglevel": {
             "version": "1.7.1",
@@ -14700,12 +15326,12 @@
             ]
         },
         "node_modules/micromatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
             "dependencies": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.2.3"
+                "braces": "^3.0.2",
+                "picomatch": "^2.3.1"
             },
             "engines": {
                 "node": ">=8.6"
@@ -15098,6 +15724,12 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+        },
+        "node_modules/natural-compare-lite": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+            "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+            "dev": true
         },
         "node_modules/negotiator": {
             "version": "0.6.2",
@@ -15543,9 +16175,9 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-            "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+            "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -16259,14 +16891,26 @@
             }
         },
         "node_modules/picomatch": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-            "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "engines": {
                 "node": ">=8.6"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/pidtree": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+            "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+            "dev": true,
+            "bin": {
+                "pidtree": "bin/pidtree.js"
+            },
+            "engines": {
+                "node": ">=0.10"
             }
         },
         "node_modules/pify": {
@@ -18689,12 +19333,143 @@
                 "semver": "bin/semver"
             }
         },
+        "node_modules/react-scripts/node_modules/@typescript-eslint/eslint-plugin": {
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
+            "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+            "dependencies": {
+                "@typescript-eslint/experimental-utils": "4.33.0",
+                "@typescript-eslint/scope-manager": "4.33.0",
+                "debug": "^4.3.1",
+                "functional-red-black-tree": "^1.0.1",
+                "ignore": "^5.1.8",
+                "regexpp": "^3.1.0",
+                "semver": "^7.3.5",
+                "tsutils": "^3.21.0"
+            },
+            "engines": {
+                "node": "^10.12.0 || >=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": "^4.0.0",
+                "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-scripts/node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+            "version": "7.3.7",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/react-scripts/node_modules/@typescript-eslint/parser": {
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
+            "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "4.33.0",
+                "@typescript-eslint/types": "4.33.0",
+                "@typescript-eslint/typescript-estree": "4.33.0",
+                "debug": "^4.3.1"
+            },
+            "engines": {
+                "node": "^10.12.0 || >=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/react-scripts/node_modules/dotenv": {
             "version": "8.2.0",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
             "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/react-scripts/node_modules/eslint-config-react-app": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz",
+            "integrity": "sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==",
+            "dependencies": {
+                "confusing-browser-globals": "^1.0.10"
+            },
+            "engines": {
+                "node": "^10.12.0 || >=12.0.0"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/eslint-plugin": "^4.0.0",
+                "@typescript-eslint/parser": "^4.0.0",
+                "babel-eslint": "^10.0.0",
+                "eslint": "^7.5.0",
+                "eslint-plugin-flowtype": "^5.2.0",
+                "eslint-plugin-import": "^2.22.0",
+                "eslint-plugin-jest": "^24.0.0",
+                "eslint-plugin-jsx-a11y": "^6.3.1",
+                "eslint-plugin-react": "^7.20.3",
+                "eslint-plugin-react-hooks": "^4.0.8",
+                "eslint-plugin-testing-library": "^3.9.0"
+            },
+            "peerDependenciesMeta": {
+                "eslint-plugin-jest": {
+                    "optional": true
+                },
+                "eslint-plugin-testing-library": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-scripts/node_modules/eslint-plugin-jest": {
+            "version": "24.7.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.7.0.tgz",
+            "integrity": "sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==",
+            "dependencies": {
+                "@typescript-eslint/experimental-utils": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/eslint-plugin": ">= 4",
+                "eslint": ">=5"
+            },
+            "peerDependenciesMeta": {
+                "@typescript-eslint/eslint-plugin": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-scripts/node_modules/ignore": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "node_modules/react-textarea-autosize": {
@@ -19295,6 +20070,19 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/restore-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+            "dev": true,
+            "dependencies": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/ret": {
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -19338,6 +20126,12 @@
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
             "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA="
+        },
+        "node_modules/rfdc": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+            "dev": true
         },
         "node_modules/rgb-regex": {
             "version": "1.0.1",
@@ -19510,6 +20304,15 @@
             "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
             "dependencies": {
                 "aproba": "^1.1.1"
+            }
+        },
+        "node_modules/rxjs": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+            "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.1.0"
             }
         },
         "node_modules/sade": {
@@ -20157,9 +20960,9 @@
             }
         },
         "node_modules/signal-exit": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
         },
         "node_modules/simple-swizzle": {
             "version": "0.2.2",
@@ -20869,6 +21672,15 @@
                     "url": "https://feross.org/support"
                 }
             ]
+        },
+        "node_modules/string-argv": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+            "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6.19"
+            }
         },
         "node_modules/string-length": {
             "version": "4.0.2",
@@ -27723,23 +28535,65 @@
             "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw=="
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "4.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.1.tgz",
-            "integrity": "sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==",
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.27.1.tgz",
+            "integrity": "sha512-6dM5NKT57ZduNnJfpY81Phe9nc9wolnMCnknb1im6brWi1RYv84nbMS3olJa27B6+irUVV1X/Wb+Am0FjJdGFw==",
+            "dev": true,
             "requires": {
-                "@typescript-eslint/experimental-utils": "4.29.1",
-                "@typescript-eslint/scope-manager": "4.29.1",
-                "debug": "^4.3.1",
+                "@typescript-eslint/scope-manager": "5.27.1",
+                "@typescript-eslint/type-utils": "5.27.1",
+                "@typescript-eslint/utils": "5.27.1",
+                "debug": "^4.3.4",
                 "functional-red-black-tree": "^1.0.1",
-                "regexpp": "^3.1.0",
-                "semver": "^7.3.5",
+                "ignore": "^5.2.0",
+                "regexpp": "^3.2.0",
+                "semver": "^7.3.7",
                 "tsutils": "^3.21.0"
             },
             "dependencies": {
+                "@typescript-eslint/scope-manager": {
+                    "version": "5.27.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+                    "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.27.1",
+                        "@typescript-eslint/visitor-keys": "5.27.1"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "5.27.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+                    "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+                    "dev": true
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "5.27.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+                    "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.27.1",
+                        "eslint-visitor-keys": "^3.3.0"
+                    }
+                },
+                "eslint-visitor-keys": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+                    "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+                    "dev": true
+                },
+                "ignore": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+                    "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+                    "dev": true
+                },
                 "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "version": "7.3.7",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+                    "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+                    "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
@@ -27747,50 +28601,120 @@
             }
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "4.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.1.tgz",
-            "integrity": "sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==",
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
+            "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
             "requires": {
                 "@types/json-schema": "^7.0.7",
-                "@typescript-eslint/scope-manager": "4.29.1",
-                "@typescript-eslint/types": "4.29.1",
-                "@typescript-eslint/typescript-estree": "4.29.1",
+                "@typescript-eslint/scope-manager": "4.33.0",
+                "@typescript-eslint/types": "4.33.0",
+                "@typescript-eslint/typescript-estree": "4.33.0",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0"
             }
         },
         "@typescript-eslint/parser": {
-            "version": "4.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.1.tgz",
-            "integrity": "sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==",
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.27.1.tgz",
+            "integrity": "sha512-7Va2ZOkHi5NP+AZwb5ReLgNF6nWLGTeUJfxdkVUAPPSaAdbWNnFZzLZ4EGGmmiCTg+AwlbE1KyUYTBglosSLHQ==",
+            "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "4.29.1",
-                "@typescript-eslint/types": "4.29.1",
-                "@typescript-eslint/typescript-estree": "4.29.1",
-                "debug": "^4.3.1"
+                "@typescript-eslint/scope-manager": "5.27.1",
+                "@typescript-eslint/types": "5.27.1",
+                "@typescript-eslint/typescript-estree": "5.27.1",
+                "debug": "^4.3.4"
+            },
+            "dependencies": {
+                "@typescript-eslint/scope-manager": {
+                    "version": "5.27.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+                    "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.27.1",
+                        "@typescript-eslint/visitor-keys": "5.27.1"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "5.27.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+                    "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+                    "dev": true
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "5.27.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
+                    "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.27.1",
+                        "@typescript-eslint/visitor-keys": "5.27.1",
+                        "debug": "^4.3.4",
+                        "globby": "^11.1.0",
+                        "is-glob": "^4.0.3",
+                        "semver": "^7.3.7",
+                        "tsutils": "^3.21.0"
+                    }
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "5.27.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+                    "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.27.1",
+                        "eslint-visitor-keys": "^3.3.0"
+                    }
+                },
+                "eslint-visitor-keys": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+                    "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.3.7",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+                    "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                }
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "4.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz",
-            "integrity": "sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==",
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
+            "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
             "requires": {
-                "@typescript-eslint/types": "4.29.1",
-                "@typescript-eslint/visitor-keys": "4.29.1"
+                "@typescript-eslint/types": "4.33.0",
+                "@typescript-eslint/visitor-keys": "4.33.0"
+            }
+        },
+        "@typescript-eslint/type-utils": {
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.27.1.tgz",
+            "integrity": "sha512-+UC1vVUWaDHRnC2cQrCJ4QtVjpjjCgjNFpg8b03nERmkHv9JV9X5M19D7UFMd+/G7T/sgFwX2pGmWK38rqyvXw==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/utils": "5.27.1",
+                "debug": "^4.3.4",
+                "tsutils": "^3.21.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "4.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.1.tgz",
-            "integrity": "sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA=="
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
+            "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ=="
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "4.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz",
-            "integrity": "sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==",
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
+            "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
             "requires": {
-                "@typescript-eslint/types": "4.29.1",
-                "@typescript-eslint/visitor-keys": "4.29.1",
+                "@typescript-eslint/types": "4.33.0",
+                "@typescript-eslint/visitor-keys": "4.33.0",
                 "debug": "^4.3.1",
                 "globby": "^11.0.3",
                 "is-glob": "^4.0.1",
@@ -27799,9 +28723,81 @@
             },
             "dependencies": {
                 "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "version": "7.3.7",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+                    "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                }
+            }
+        },
+        "@typescript-eslint/utils": {
+            "version": "5.27.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.27.1.tgz",
+            "integrity": "sha512-mZ9WEn1ZLDaVrhRaYgzbkXBkTPghPFsup8zDbbsYTxC5OmqrFE7skkKS/sraVsLP3TcT3Ki5CSyEFBRkLH/H/w==",
+            "dev": true,
+            "requires": {
+                "@types/json-schema": "^7.0.9",
+                "@typescript-eslint/scope-manager": "5.27.1",
+                "@typescript-eslint/types": "5.27.1",
+                "@typescript-eslint/typescript-estree": "5.27.1",
+                "eslint-scope": "^5.1.1",
+                "eslint-utils": "^3.0.0"
+            },
+            "dependencies": {
+                "@typescript-eslint/scope-manager": {
+                    "version": "5.27.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+                    "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.27.1",
+                        "@typescript-eslint/visitor-keys": "5.27.1"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "5.27.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+                    "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+                    "dev": true
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "5.27.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
+                    "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.27.1",
+                        "@typescript-eslint/visitor-keys": "5.27.1",
+                        "debug": "^4.3.4",
+                        "globby": "^11.1.0",
+                        "is-glob": "^4.0.3",
+                        "semver": "^7.3.7",
+                        "tsutils": "^3.21.0"
+                    }
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "5.27.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+                    "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.27.1",
+                        "eslint-visitor-keys": "^3.3.0"
+                    }
+                },
+                "eslint-visitor-keys": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+                    "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.3.7",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+                    "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+                    "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
@@ -27809,11 +28805,11 @@
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "4.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz",
-            "integrity": "sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==",
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
+            "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
             "requires": {
-                "@typescript-eslint/types": "4.29.1",
+                "@typescript-eslint/types": "4.33.0",
                 "eslint-visitor-keys": "^2.0.0"
             }
         },
@@ -29489,6 +30485,75 @@
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
             "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
         },
+        "cli-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+            "dev": true,
+            "requires": {
+                "restore-cursor": "^3.1.0"
+            }
+        },
+        "cli-truncate": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
+            "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
+            "dev": true,
+            "requires": {
+                "slice-ansi": "^5.0.0",
+                "string-width": "^5.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+                    "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.1.0.tgz",
+                    "integrity": "sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+                    "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+                    "dev": true
+                },
+                "slice-ansi": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+                    "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^6.0.0",
+                        "is-fullwidth-code-point": "^4.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+                    "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+                    "dev": true,
+                    "requires": {
+                        "eastasianwidth": "^0.2.0",
+                        "emoji-regex": "^9.2.2",
+                        "strip-ansi": "^7.0.1"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+                    "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^6.0.1"
+                    }
+                }
+            }
+        },
         "cliui": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -29546,103 +30611,6 @@
             "dev": true,
             "requires": {
                 "tslib": "2.3.1"
-            }
-        },
-        "collation": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/collation/-/collation-0.9.0.tgz",
-            "integrity": "sha512-qqKmHKCel6RLItn7rjiJgijWgGpj7jANVLDllZV3AnmmJU1IxystKmtDtuFym8VJ1QhlAvscaLZh/Mgn47LO+Q==",
-            "dev": true,
-            "requires": {
-                "chalk": "4.0.0",
-                "commander": "8.3.0",
-                "diff": "5.0.0",
-                "fuzzaldrin": "2.1.0",
-                "lodash": "4.17.21",
-                "source-map-support": "^0.5.21",
-                "ts-morph": "13.0.3"
-            },
-            "dependencies": {
-                "@ts-morph/common": {
-                    "version": "0.12.3",
-                    "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.12.3.tgz",
-                    "integrity": "sha512-4tUmeLyXJnJWvTFOKtcNJ1yh0a3SsTLi2MUoyj8iUNznFRN1ZquaNe7Oukqrnki2FzZkm0J9adCNLDZxUzvj+w==",
-                    "dev": true,
-                    "requires": {
-                        "fast-glob": "^3.2.7",
-                        "minimatch": "^3.0.4",
-                        "mkdirp": "^1.0.4",
-                        "path-browserify": "^1.0.1"
-                    }
-                },
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-                    "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
-                },
-                "commander": {
-                    "version": "8.3.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-                    "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-                    "dev": true
-                },
-                "diff": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-                    "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-                    "dev": true
-                },
-                "mkdirp": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-                    "dev": true
-                },
-                "path-browserify": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-                    "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-                    "dev": true
-                },
-                "ts-morph": {
-                    "version": "13.0.3",
-                    "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-13.0.3.tgz",
-                    "integrity": "sha512-pSOfUMx8Ld/WUreoSzvMFQG5i9uEiWIsBYjpU9+TTASOeUa89j5HykomeqVULm1oqWtBdleI3KEFRLrlA3zGIw==",
-                    "dev": true,
-                    "requires": {
-                        "@ts-morph/common": "~0.12.3",
-                        "code-block-writer": "^11.0.0"
-                    }
-                }
             }
         },
         "collect-v8-coverage": {
@@ -29795,9 +30763,9 @@
             }
         },
         "confusing-browser-globals": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
-            "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA=="
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
+            "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA=="
         },
         "connect-history-api-fallback": {
             "version": "1.6.0",
@@ -30388,9 +31356,9 @@
             }
         },
         "debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "requires": {
                 "ms": "2.1.2"
             }
@@ -30910,6 +31878,12 @@
                 "stream-shift": "^1.0.0"
             }
         },
+        "eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "dev": true
+        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -31278,14 +32252,6 @@
                 }
             }
         },
-        "eslint-config-react-app": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz",
-            "integrity": "sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==",
-            "requires": {
-                "confusing-browser-globals": "^1.0.10"
-            }
-        },
         "eslint-import-resolver-node": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
@@ -31332,6 +32298,13 @@
                     }
                 }
             }
+        },
+        "eslint-plugin-collation": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-collation/-/eslint-plugin-collation-1.0.2.tgz",
+            "integrity": "sha512-QIWb4VkKuXzEGPq+lIvN3GAD1S/hq5fFmm+/rHr9lRwPO+9Z7rm6lEYXeWPQaq/hI3y5x48Ra3WhbNEImAgC/Q==",
+            "dev": true,
+            "requires": {}
         },
         "eslint-plugin-flowtype": {
             "version": "5.9.0",
@@ -31437,14 +32410,6 @@
                         "path-parse": "^1.0.6"
                     }
                 }
-            }
-        },
-        "eslint-plugin-jest": {
-            "version": "24.4.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.4.0.tgz",
-            "integrity": "sha512-8qnt/hgtZ94E9dA6viqfViKBfkJwFHXgJmTWlMGDgunw1XJEGqm3eiPjDsTanM3/u/3Az82nyQM9GX7PM/QGmg==",
-            "requires": {
-                "@typescript-eslint/experimental-utils": "^4.0.1"
             }
         },
         "eslint-plugin-jsx-a11y": {
@@ -31569,6 +32534,28 @@
                     "version": "1.3.0",
                     "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
                     "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+                }
+            }
+        },
+        "eslint-plugin-typescript-sort-keys": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-typescript-sort-keys/-/eslint-plugin-typescript-sort-keys-2.1.0.tgz",
+            "integrity": "sha512-ET7ABypdz19m47QnKynzNfWPi4CTNQ5jQQC1X5d0gojIwblkbGiCa5IilsqzBTmqxZ0yXDqKBO/GBkBFQCOFsg==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/experimental-utils": "^5.0.0",
+                "json-schema": "^0.4.0",
+                "natural-compare-lite": "^1.4.0"
+            },
+            "dependencies": {
+                "@typescript-eslint/experimental-utils": {
+                    "version": "5.27.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.27.1.tgz",
+                    "integrity": "sha512-Vd8uewIixGP93sEnmTRIH6jHZYRQRkGPDPpapACMvitJKX8335VHNyqKTE+mZ+m3E2c5VznTZfSsSsS5IF7vUA==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/utils": "5.27.1"
+                    }
                 }
             }
         },
@@ -32563,12 +33550,6 @@
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
         },
-        "fuzzaldrin": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fuzzaldrin/-/fuzzaldrin-2.1.0.tgz",
-            "integrity": "sha1-kCBMPi/appQbso0WZF1BgGOpDps=",
-            "dev": true
-        },
         "fuzzaldrin-plus": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/fuzzaldrin-plus/-/fuzzaldrin-plus-0.6.0.tgz",
@@ -32695,22 +33676,22 @@
             "dev": true
         },
         "globby": {
-            "version": "11.0.4",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-            "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
             "requires": {
                 "array-union": "^2.1.0",
                 "dir-glob": "^3.0.1",
-                "fast-glob": "^3.1.1",
-                "ignore": "^5.1.4",
-                "merge2": "^1.3.0",
+                "fast-glob": "^3.2.9",
+                "ignore": "^5.2.0",
+                "merge2": "^1.4.1",
                 "slash": "^3.0.0"
             },
             "dependencies": {
                 "ignore": {
-                    "version": "5.1.8",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-                    "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+                    "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
                 }
             }
         },
@@ -33606,9 +34587,9 @@
             "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ=="
         },
         "is-glob": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "requires": {
                 "is-extglob": "^2.1.1"
             }
@@ -34664,6 +35645,12 @@
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
         },
+        "json-schema": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+            "dev": true
+        },
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -34766,10 +35753,208 @@
                 "type-check": "~0.4.0"
             }
         },
+        "lilconfig": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
+            "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
+            "dev": true
+        },
         "lines-and-columns": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
             "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+        },
+        "lint-staged": {
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.0.1.tgz",
+            "integrity": "sha512-Ykaf4QTi0a02BF7cnq7JIPGOJxH4TkNMWhSlJdH9wOekd0X+gog47Jfh/0L31DqZe5AiydLGC7LkPqpaNm+Kvg==",
+            "dev": true,
+            "requires": {
+                "cli-truncate": "^3.1.0",
+                "colorette": "^2.0.17",
+                "commander": "^9.3.0",
+                "debug": "^4.3.4",
+                "execa": "^6.1.0",
+                "lilconfig": "2.0.5",
+                "listr2": "^4.0.5",
+                "micromatch": "^4.0.5",
+                "normalize-path": "^3.0.0",
+                "object-inspect": "^1.12.2",
+                "pidtree": "^0.6.0",
+                "string-argv": "^0.3.1",
+                "yaml": "^2.1.1"
+            },
+            "dependencies": {
+                "colorette": {
+                    "version": "2.0.17",
+                    "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.17.tgz",
+                    "integrity": "sha512-hJo+3Bkn0NCHybn9Tu35fIeoOKGOk5OCC32y4Hz2It+qlCO2Q3DeQ1hRn/tDDMQKRYUEzqsl7jbF6dYKjlE60g==",
+                    "dev": true
+                },
+                "commander": {
+                    "version": "9.3.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz",
+                    "integrity": "sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==",
+                    "dev": true
+                },
+                "execa": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+                    "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^7.0.3",
+                        "get-stream": "^6.0.1",
+                        "human-signals": "^3.0.1",
+                        "is-stream": "^3.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^5.1.0",
+                        "onetime": "^6.0.0",
+                        "signal-exit": "^3.0.7",
+                        "strip-final-newline": "^3.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+                    "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+                    "dev": true
+                },
+                "human-signals": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+                    "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+                    "dev": true
+                },
+                "is-stream": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+                    "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+                    "dev": true
+                },
+                "mimic-fn": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+                    "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+                    "dev": true
+                },
+                "npm-run-path": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+                    "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^4.0.0"
+                    }
+                },
+                "onetime": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+                    "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^4.0.0"
+                    }
+                },
+                "path-key": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+                    "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+                    "dev": true
+                },
+                "strip-final-newline": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+                    "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+                    "dev": true
+                },
+                "yaml": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+                    "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+                    "dev": true
+                }
+            }
+        },
+        "listr2": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
+            "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
+            "dev": true,
+            "requires": {
+                "cli-truncate": "^2.1.0",
+                "colorette": "^2.0.16",
+                "log-update": "^4.0.0",
+                "p-map": "^4.0.0",
+                "rfdc": "^1.3.0",
+                "rxjs": "^7.5.5",
+                "through": "^2.3.8",
+                "wrap-ansi": "^7.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "cli-truncate": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+                    "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+                    "dev": true,
+                    "requires": {
+                        "slice-ansi": "^3.0.0",
+                        "string-width": "^4.2.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "colorette": {
+                    "version": "2.0.17",
+                    "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.17.tgz",
+                    "integrity": "sha512-hJo+3Bkn0NCHybn9Tu35fIeoOKGOk5OCC32y4Hz2It+qlCO2Q3DeQ1hRn/tDDMQKRYUEzqsl7jbF6dYKjlE60g==",
+                    "dev": true
+                },
+                "slice-ansi": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+                    "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "astral-regex": "^2.0.0",
+                        "is-fullwidth-code-point": "^3.0.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+                    "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                }
+            }
         },
         "load-json-file": {
             "version": "4.0.0",
@@ -34897,6 +36082,18 @@
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
             "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
+        },
+        "log-update": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+            "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^4.3.0",
+                "cli-cursor": "^3.1.0",
+                "slice-ansi": "^4.0.0",
+                "wrap-ansi": "^6.2.0"
+            }
         },
         "loglevel": {
             "version": "1.7.1",
@@ -35672,12 +36869,12 @@
             "integrity": "sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w=="
         },
         "micromatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
             "requires": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.2.3"
+                "braces": "^3.0.2",
+                "picomatch": "^2.3.1"
             }
         },
         "microseconds": {
@@ -35984,6 +37181,12 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+        },
+        "natural-compare-lite": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+            "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+            "dev": true
         },
         "negotiator": {
             "version": "0.6.2",
@@ -36337,9 +37540,9 @@
             }
         },
         "object-inspect": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-            "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+            "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
         },
         "object-is": {
             "version": "1.1.5",
@@ -36878,9 +38081,15 @@
             }
         },
         "picomatch": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-            "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+        },
+        "pidtree": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+            "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+            "dev": true
         },
         "pify": {
             "version": "4.0.1",
@@ -38795,10 +40004,67 @@
                         }
                     }
                 },
+                "@typescript-eslint/eslint-plugin": {
+                    "version": "4.33.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
+                    "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+                    "requires": {
+                        "@typescript-eslint/experimental-utils": "4.33.0",
+                        "@typescript-eslint/scope-manager": "4.33.0",
+                        "debug": "^4.3.1",
+                        "functional-red-black-tree": "^1.0.1",
+                        "ignore": "^5.1.8",
+                        "regexpp": "^3.1.0",
+                        "semver": "^7.3.5",
+                        "tsutils": "^3.21.0"
+                    },
+                    "dependencies": {
+                        "semver": {
+                            "version": "7.3.7",
+                            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+                            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+                            "requires": {
+                                "lru-cache": "^6.0.0"
+                            }
+                        }
+                    }
+                },
+                "@typescript-eslint/parser": {
+                    "version": "4.33.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
+                    "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+                    "requires": {
+                        "@typescript-eslint/scope-manager": "4.33.0",
+                        "@typescript-eslint/types": "4.33.0",
+                        "@typescript-eslint/typescript-estree": "4.33.0",
+                        "debug": "^4.3.1"
+                    }
+                },
                 "dotenv": {
                     "version": "8.2.0",
                     "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
                     "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+                },
+                "eslint-config-react-app": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz",
+                    "integrity": "sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==",
+                    "requires": {
+                        "confusing-browser-globals": "^1.0.10"
+                    }
+                },
+                "eslint-plugin-jest": {
+                    "version": "24.7.0",
+                    "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.7.0.tgz",
+                    "integrity": "sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==",
+                    "requires": {
+                        "@typescript-eslint/experimental-utils": "^4.0.1"
+                    }
+                },
+                "ignore": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+                    "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
                 }
             }
         },
@@ -39267,6 +40533,16 @@
                 }
             }
         },
+        "restore-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+            "dev": true,
+            "requires": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+            }
+        },
         "ret": {
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -39302,6 +40578,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/rework-visit/-/rework-visit-1.0.0.tgz",
             "integrity": "sha1-mUWygD8hni96ygCtuLyfZA+ELJo="
+        },
+        "rfdc": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+            "dev": true
         },
         "rgb-regex": {
             "version": "1.0.1",
@@ -39431,6 +40713,15 @@
             "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
             "requires": {
                 "aproba": "^1.1.1"
+            }
+        },
+        "rxjs": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+            "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.1.0"
             }
         },
         "sade": {
@@ -39946,9 +41237,9 @@
             }
         },
         "signal-exit": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
         },
         "simple-swizzle": {
             "version": "0.2.2",
@@ -40543,6 +41834,12 @@
                     "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
                 }
             }
+        },
+        "string-argv": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+            "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+            "dev": true
         },
         "string-length": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -62,11 +62,15 @@
         "@types/react-dom": "18.0.1",
         "@types/react-router-dom": "5.3.3",
         "@types/uuid": "8.3.1",
+        "@typescript-eslint/eslint-plugin": "5.27.1",
+        "@typescript-eslint/parser": "5.27.1",
         "chalk": "4.1.2",
-        "collation": "0.9.0",
         "dotenv": "10.0.0",
+        "eslint-plugin-collation": "1.0.2",
+        "eslint-plugin-typescript-sort-keys": "2.1.0",
         "husky": "7.0.4",
         "jest-extended": "1.2.1",
+        "lint-staged": "13.0.1",
         "node-pg-migrate": "6.0.0",
         "openapi-typescript": "4.4.0",
         "pluralize": "8.0.0",
@@ -85,6 +89,10 @@
             "react-app/jest"
         ]
     },
+    "lint-staged": {
+        "*.{ts,tsx,json,md}": "prettier --ignore-unknown --write",
+        "*.{ts,tsx}": "eslint --fix"
+    },
     "name": "beets",
     "private": true,
     "scripts": {
@@ -94,8 +102,10 @@
         "clean:migrations": "rm -rf src/scripts/migrations/dist",
         "codegen": "ts-node src/scripts/codegen/main.ts",
         "eject": "react-scripts eject",
-        "lint": "prettier src --check && eslint src",
-        "format": "prettier src --write && eslint src --fix",
+        "format:check": "prettier src --ignore-unknown --check",
+        "format:fix": "prettier src --ignore-unknown --write",
+        "lint": "eslint 'src/**/*.{ts,tsx}'",
+        "lint:fix": "npm run lint -- --fix",
         "migrations:create": "node-pg-migrate --migrations-dir src/scripts/migrations --template-file-name src/scripts/migrations/utils/migration-template.ts create",
         "migrations:down": "node-pg-migrate --migrations-dir src/scripts/migrations/dist down",
         "migrations:up": "node-pg-migrate --migrations-dir src/scripts/migrations/dist up",

--- a/src/components/change-password-form.tsx
+++ b/src/components/change-password-form.tsx
@@ -135,7 +135,7 @@ const ChangePasswordForm: React.FC<ChangePasswordFormProps> = (
                 />
                 <Button
                     disabled={
-                        passwordValidation?.isInvalid ||
+                        passwordValidation?.isInvalid === true ||
                         passwordConfirmationValidation.isInvalid
                     }
                     isLoading={isLoading}

--- a/src/components/confirm-button.tsx
+++ b/src/components/confirm-button.tsx
@@ -2,8 +2,8 @@ import { Alert, Button, ButtonProps, majorScale } from "evergreen-ui";
 import React, { PropsWithChildren, useCallback, useState } from "react";
 
 interface ConfirmButtonProps extends Omit<ButtonProps, "onClick"> {
-    alertDescription?: string | React.ReactNode;
-    alertTitle?: string | React.ReactNode;
+    alertDescription?: React.ReactNode | string;
+    alertTitle?: React.ReactNode | string;
     onClick?: () => void;
     onConfirm?: () => void;
 }

--- a/src/components/contextual-icon-button.tsx
+++ b/src/components/contextual-icon-button.tsx
@@ -23,7 +23,7 @@ interface ContextualIconButtonProps
     tooltipText: string;
 }
 
-type VisibilityState = "visible" | "hidden";
+type VisibilityState = "hidden" | "visible";
 
 const ContextualIconButton: React.FC<ContextualIconButtonProps> = (
     props: ContextualIconButtonProps

--- a/src/components/dialog-footer.tsx
+++ b/src/components/dialog-footer.tsx
@@ -4,12 +4,12 @@ import React from "react";
 interface DialogFooterProps
     extends Pick<
         DialogProps,
-        | "intent"
-        | "hasCancel"
         | "cancelLabel"
-        | "isConfirmLoading"
-        | "isConfirmDisabled"
         | "confirmLabel"
+        | "hasCancel"
+        | "intent"
+        | "isConfirmDisabled"
+        | "isConfirmLoading"
     > {
     onCancel?: () => void;
     onConfirm?: () => void;

--- a/src/components/empty-state.tsx
+++ b/src/components/empty-state.tsx
@@ -12,8 +12,8 @@ interface EmptyStateProps
 }
 
 const EmptyState: React.FC<EmptyStateProps> & {
-    PrimaryButton: typeof EvergreenEmptyState.PrimaryButton;
     LinkButton: typeof EvergreenEmptyState.LinkButton;
+    PrimaryButton: typeof EvergreenEmptyState.PrimaryButton;
 } = (props: EmptyStateProps) => {
     const { colors } = useTheme();
     const {

--- a/src/components/files/file-card.tsx
+++ b/src/components/files/file-card.tsx
@@ -20,7 +20,7 @@ import { Flex } from "components/flex";
 import { IconButton } from "components/icon-button";
 
 interface FileCardProps
-    extends Omit<EvergreenFileCardProps, "name" | "type" | "sizeInBytes"> {
+    extends Omit<EvergreenFileCardProps, "name" | "sizeInBytes" | "type"> {
     file: FileRecord;
     storageProviderFile: StorageProviderFileRecord;
 }

--- a/src/components/files/file-select-menu-filter-popover.tsx
+++ b/src/components/files/file-select-menu-filter-popover.tsx
@@ -23,7 +23,7 @@ import React, { useCallback, useState } from "react";
 import { useTheme } from "utils/hooks/use-theme";
 
 interface FileSelectMenuFilterPopoverProps
-    extends Pick<PopoverProps, "onOpen" | "onClose"> {
+    extends Pick<PopoverProps, "onClose" | "onOpen"> {
     filters: FileSelectMenuFilters;
     onConfirm: (updated: FileSelectMenuFilters) => void;
 }

--- a/src/components/files/file-settings-dialog.tsx
+++ b/src/components/files/file-settings-dialog.tsx
@@ -28,7 +28,7 @@ const FileSettingsDialog: React.FC<FileSettingsDialogProps> = (
     });
 
     const handleSave = useCallback(() => {
-        if (nameValidation.isInvalid) {
+        if (nameValidation.isInvalid === true) {
             return;
         }
 

--- a/src/components/forms/form-dialog.tsx
+++ b/src/components/forms/form-dialog.tsx
@@ -5,7 +5,7 @@ import { DialogFooter } from "components/dialog-footer";
 
 interface FormDialogProps
     extends Omit<DialogProps, "onConfirm">,
-        Omit<FormProps, "children" | "onSubmit" | "width" | "title"> {
+        Omit<FormProps, "children" | "onSubmit" | "title" | "width"> {
     onSubmit?: (close: () => void) => void;
 }
 

--- a/src/components/forms/form.tsx
+++ b/src/components/forms/form.tsx
@@ -15,5 +15,4 @@ const Form: React.FC<PropsWithChildren<FormProps>> = (
 };
 
 export { Form };
-
 export type { FormProps };

--- a/src/components/icon-button.tsx
+++ b/src/components/icon-button.tsx
@@ -12,7 +12,12 @@ interface IconButtonProps extends EvergreenIconButtonProps {}
  */
 const IconButton: React.FC<IconButtonProps> = forwardRef(
     (props: IconButtonProps, ref: ForwardedRef<HTMLButtonElement>) => {
-        const { icon: iconProp, disabled, isLoading, ...rest } = props;
+        const {
+            icon: iconProp,
+            disabled = false,
+            isLoading = false,
+            ...rest
+        } = props;
 
         const icon = isLoading ? <Spinner /> : iconProp;
 

--- a/src/components/instruments/instrument-settings.tsx
+++ b/src/components/instruments/instrument-settings.tsx
@@ -168,7 +168,10 @@ const InstrumentSettings: React.FC<InstrumentSettingsProps> = (
     );
 
     const handleSubmit = useCallback(() => {
-        if (nameValidation?.isInvalid || releaseValidation.isInvalid) {
+        if (
+            nameValidation?.isInvalid === true ||
+            releaseValidation.isInvalid === true
+        ) {
             return;
         }
 
@@ -329,7 +332,9 @@ const InstrumentSettings: React.FC<InstrumentSettingsProps> = (
                     selected={file}>
                     <Button
                         intent={
-                            fileValidation?.isInvalid ? "danger" : undefined
+                            fileValidation?.isInvalid === true
+                                ? "danger"
+                                : undefined
                         }
                         type="button"
                         width="100%">
@@ -348,7 +353,7 @@ const InstrumentSettings: React.FC<InstrumentSettingsProps> = (
                     width="100%"
                 />
             </FormField>
-            {initialInstrument?.isPersisted() && (
+            {initialInstrument?.isPersisted() === true && (
                 <ConfirmButton
                     alertDescription="Click Delete Instrument again to confirm this action."
                     alertTitle="This will permanently delete your instrument and all of its tracks."

--- a/src/components/instruments/instruments-table.tsx
+++ b/src/components/instruments/instruments-table.tsx
@@ -8,8 +8,8 @@ import { FileRecord } from "models/file-record";
 
 interface InstrumentsTableProps extends Pick<TableRowProps, "isSelectable"> {
     emptyState?: React.ReactNode;
-    files?: List<FileRecord> | FileRecord[];
-    instruments?: List<InstrumentRecord> | InstrumentRecord[];
+    files?: FileRecord[] | List<FileRecord>;
+    instruments?: InstrumentRecord[] | List<InstrumentRecord>;
     isLoading?: boolean;
     onDeselect?: (instrument: InstrumentRecord) => void;
     onSelect?: (instrument: InstrumentRecord) => void;
@@ -24,7 +24,7 @@ const InstrumentsTable: React.FC<InstrumentsTableProps> = (
         onDeselect,
         onSelect,
         selected,
-        isLoading,
+        isLoading = false,
         emptyState,
         instruments,
         files,

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -6,9 +6,9 @@ import { useTheme } from "utils/hooks/use-theme";
 interface MenuProps {}
 
 const Menu: React.FC<PropsWithChildren<MenuProps>> & {
-    Item: typeof MenuItem;
-    Group: typeof EvergreenMenu.Group;
     Divider: typeof EvergreenMenu.Divider;
+    Group: typeof EvergreenMenu.Group;
+    Item: typeof MenuItem;
     Option: typeof EvergreenMenu.Option;
     OptionsGroup: typeof EvergreenMenu.OptionsGroup;
 } = (props: PropsWithChildren<MenuProps>) => {

--- a/src/components/pages/workstation-page.tsx
+++ b/src/components/pages/workstation-page.tsx
@@ -111,7 +111,7 @@ const WorkstationPage: React.FC<WorkstationPageProps> = (
             return;
         }
 
-        if (workstations?.isEmpty()) {
+        if (workstations?.isEmpty() === true) {
             setState(new WorkstationStateRecord());
             return;
         }

--- a/src/components/piano-roll/piano-roll.tsx
+++ b/src/components/piano-roll/piano-roll.tsx
@@ -42,7 +42,7 @@ const PianoRoll: React.FC<PianoRollProps> = (props: PianoRollProps) => {
     const {
         instrument,
         file,
-        centerControls,
+        centerControls = false,
         onChange,
         onStepCountChange,
         stepCount,

--- a/src/components/select-menu/select-menu.tsx
+++ b/src/components/select-menu/select-menu.tsx
@@ -10,7 +10,7 @@ import { intersectionWith, isArray, pick } from "lodash";
 import { useCallback, useMemo } from "react";
 import { isEqual, isNotNilOrEmpty } from "utils/core-utils";
 
-type FirstParameter<TFunction extends undefined | ((...args: any[]) => any)> =
+type FirstParameter<TFunction extends ((...args: any[]) => any) | undefined> =
     Parameters<NonNullable<TFunction>>[0];
 
 type EvergreenSelectMenuItemRenderer = EvergreenSelectMenuProps["itemRenderer"];
@@ -18,7 +18,7 @@ type EvergreenSelectMenuItemRenderer = EvergreenSelectMenuProps["itemRenderer"];
 interface SelectMenuProps<T>
     extends Omit<
         EvergreenSelectMenuProps,
-        "onDeselect" | "onSelect" | "options" | "selected" | "itemRenderer"
+        "itemRenderer" | "onDeselect" | "onSelect" | "options" | "selected"
     > {
     /** Calculate height of menu based on # of items */
     calculateHeight?: boolean;
@@ -28,7 +28,7 @@ interface SelectMenuProps<T>
     onValueDeselect?: (value: T) => void;
     onValueSelect?: (value: T) => void;
     options?: Array<SelectMenuItem<T>>;
-    selected?: T | T[] | List<T>;
+    selected?: List<T> | T | T[];
 }
 
 interface SelectMenuItem<T> extends Omit<EvergreenSelectMenuItem, "value"> {

--- a/src/components/sidebar/help-dialog/help-dialog-link.tsx
+++ b/src/components/sidebar/help-dialog/help-dialog-link.tsx
@@ -21,7 +21,7 @@ interface HelpDialogLinkProps
                 AnchorHTMLAttributes<HTMLAnchorElement>,
                 HTMLAnchorElement
             >,
-            "key" | keyof React.AnchorHTMLAttributes<any>
+            keyof React.AnchorHTMLAttributes<any> | "key"
         > &
             ReactMarkdownProps
     > {

--- a/src/components/workstation/song-controls.tsx
+++ b/src/components/workstation/song-controls.tsx
@@ -40,7 +40,7 @@ const SongControls: React.FC<SongControlsProps> = (
     const {
         toggleMute,
         toggleIsPlaying,
-        mute,
+        mute = false,
         isPlaying,
         startIndex,
         endIndex,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "app";
-import reportWebVitals from "reportWebVitals";
+import { reportWebVitals } from "reportWebVitals";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ThemeProvider } from "evergreen-ui";
 import { theme } from "theme";

--- a/src/interfaces/workstation-state.ts
+++ b/src/interfaces/workstation-state.ts
@@ -6,9 +6,9 @@ import { TrackSectionStepRecord } from "models/track-section-step-record";
 
 interface WorkstationState {
     project: ProjectRecord;
-    trackSectionSteps: List<TrackSectionStepRecord>;
-    trackSections: List<TrackSectionRecord>;
     tracks: List<TrackRecord>;
+    trackSections: List<TrackSectionRecord>;
+    trackSectionSteps: List<TrackSectionStepRecord>;
 }
 
 export type { WorkstationState };

--- a/src/models/workstation-state-record.ts
+++ b/src/models/workstation-state-record.ts
@@ -24,12 +24,12 @@ import { getByTrack } from "utils/track-section-utils";
 
 interface WorkstationStateDiff {
     createdOrUpdatedProject?: ProjectRecord;
-    createdOrUpdatedTrackSectionSteps?: List<TrackSectionStepRecord>;
-    createdOrUpdatedTrackSections?: List<TrackSectionRecord>;
     createdOrUpdatedTracks?: List<TrackRecord>;
-    deletedTrackSectionSteps?: List<TrackSectionStepRecord>;
-    deletedTrackSections?: List<TrackSectionRecord>;
+    createdOrUpdatedTrackSections?: List<TrackSectionRecord>;
+    createdOrUpdatedTrackSectionSteps?: List<TrackSectionStepRecord>;
     deletedTracks?: List<TrackRecord>;
+    deletedTrackSections?: List<TrackSectionRecord>;
+    deletedTrackSectionSteps?: List<TrackSectionStepRecord>;
 }
 
 const defaultValues = makeDefaultValues<WorkstationState>({

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,6 +1,6 @@
 import { ReportHandler } from "web-vitals";
 
-const reportWebVitals = (onPerfEntry?: ReportHandler) => {
+export const reportWebVitals = (onPerfEntry?: ReportHandler) => {
     if (onPerfEntry && onPerfEntry instanceof Function) {
         import("web-vitals").then(
             ({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
@@ -13,5 +13,3 @@ const reportWebVitals = (onPerfEntry?: ReportHandler) => {
         );
     }
 };
-
-export default reportWebVitals;

--- a/src/types/midi-note.ts
+++ b/src/types/midi-note.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/sort-type-union-intersection-members */
 export type MidiNote =
     | "C-2"
     | "C#-2"

--- a/src/types/record-params.ts
+++ b/src/types/record-params.ts
@@ -3,7 +3,7 @@ import { ExcludeImmutable } from "types/exclude-immutable";
 type RecordParams<T> = T extends Immutable.Record<infer X>
     ? ExcludeImmutable<RecordParams<X>>
     : Partial<{
-          [Property in keyof T]: T[Property] | ExcludeImmutable<T[Property]>;
+          [Property in keyof T]: ExcludeImmutable<T[Property]> | T[Property];
       }>;
 
 export type { RecordParams };

--- a/src/types/required-or-nil.ts
+++ b/src/types/required-or-nil.ts
@@ -1,5 +1,5 @@
 import { RequiredOr } from "types/required-or";
 
-type RequiredOrNil<T> = RequiredOr<T, undefined | null>;
+type RequiredOrNil<T> = RequiredOr<T, null | undefined>;
 
 export type { RequiredOrNil };

--- a/src/utils/atoms/immutable-atom-with-storage.ts
+++ b/src/utils/atoms/immutable-atom-with-storage.ts
@@ -1,7 +1,7 @@
 import { Collection, Record } from "immutable";
 import { atomWithStorage } from "jotai/utils";
 
-const immutableAtomWithStorage = <T extends Record<any> | Collection<any, any>>(
+const immutableAtomWithStorage = <T extends Collection<any, any> | Record<any>>(
     key: string,
     initialValue: T,
     constructorOrFactory: (...args: any[]) => T

--- a/src/utils/collection-utils.ts
+++ b/src/utils/collection-utils.ts
@@ -91,8 +91,8 @@ const initializeList = <T>(count: number, value: T): List<T> =>
     List(_.fill(new Array(count), value));
 
 const intersectionWith = <TLeft, TRight>(
-    leftValues: List<TLeft> | Array<TLeft>,
-    rightValues: List<TRight> | Array<TRight>,
+    leftValues: Array<TLeft> | List<TLeft>,
+    rightValues: Array<TRight> | List<TRight>,
     comparator: (left: TLeft, right: TRight) => boolean
 ): List<TLeft> => {
     if (List.isList(leftValues)) {

--- a/src/utils/core-utils.ts
+++ b/src/utils/core-utils.ts
@@ -65,8 +65,8 @@ const isInstanceOf = <T, C extends Constructor[]>(
     ...construtors: C
 ): boolean => construtors.some((constructor) => value instanceof constructor);
 
-const isNilOrEmpty = <T = string | any[] | List<any>>(
-    value: T | any[] | List<any> | null | undefined
+const isNilOrEmpty = <T = any[] | List<any> | string>(
+    value: any[] | List<any> | T | null | undefined
 ): value is null | undefined => {
     if (typeof value === "string") {
         return value.trim().length === 0;
@@ -83,8 +83,8 @@ const isNilOrEmpty = <T = string | any[] | List<any>>(
     return value == null;
 };
 
-const isNotNilOrEmpty = <T = string | any[] | List<any>>(
-    value: T | any[] | List<any> | null | undefined
+const isNotNilOrEmpty = <T = any[] | List<any> | string>(
+    value: any[] | List<any> | T | null | undefined
 ): value is T => !isNilOrEmpty(value);
 
 const makeDefaultValues = <T>(defaultValues: RequiredOrNil<T>): T =>

--- a/src/utils/data-attribute-utils.ts
+++ b/src/utils/data-attribute-utils.ts
@@ -3,7 +3,7 @@ import { Map } from "immutable";
 import { isEmpty, get } from "lodash";
 
 const toDataAttributes = (
-    values?: Partial<Record<keyof typeof DataAttributes, string | number>>
+    values?: Partial<Record<keyof typeof DataAttributes, number | string>>
 ): Record<string, unknown> => {
     let props: Map<string, unknown> = Map();
 

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -8,7 +8,7 @@ import { isNilOrEmpty } from "utils/core-utils";
 type AnyFile = FileRecord | StorageProviderFileRecord;
 
 const findFileByName = <T extends AnyFile>(
-    nameOrPattern: string | RegExp,
+    nameOrPattern: RegExp | string,
     files?: List<T>
 ): T | undefined =>
     files?.find((file) => getFileName(file).match(nameOrPattern) != null);

--- a/src/utils/hooks/use-clipboard-state.ts
+++ b/src/utils/hooks/use-clipboard-state.ts
@@ -21,8 +21,8 @@ interface UseClipboardStateResult {
     onSelect: (
         item: ClipboardItem
     ) => (event: React.MouseEvent<HTMLDivElement>) => void;
-    selectItem: (item: ClipboardItem) => void;
     selectedState: List<ClipboardItem>;
+    selectItem: (item: ClipboardItem) => void;
     setSelectedState: (update: SetStateAction<List<ClipboardItem>>) => void;
 }
 

--- a/src/utils/hooks/use-help-docs.ts
+++ b/src/utils/hooks/use-help-docs.ts
@@ -31,9 +31,9 @@ const useHelpDocs = (options?: UseHelpDocsOptions): UseHelpDocsResult => {
 const resourceToModule = (
     resource: HelpResource
 ):
-    | typeof OverviewMarkdown
+    | typeof ContributingMarkdown
     | typeof HowToMarkdown
-    | typeof ContributingMarkdown => {
+    | typeof OverviewMarkdown => {
     switch (resource) {
         case HelpResource.Contributing:
             return ContributingMarkdown;

--- a/src/utils/hooks/use-keyboard-shortcut.ts
+++ b/src/utils/hooks/use-keyboard-shortcut.ts
@@ -19,7 +19,7 @@ interface UseKeyboardShortcutResult {
  * @param dependencies Optional dependencies that the callback function needs to run properly
  */
 const useKeyboardShortcut = (
-    shortcut: string | string[],
+    shortcut: string[] | string,
     callback: (event: KeyboardEvent) => void,
     dependencies?: any[]
 ): UseKeyboardShortcutResult => {

--- a/src/utils/hooks/use-latest-release.ts
+++ b/src/utils/hooks/use-latest-release.ts
@@ -6,43 +6,42 @@ export interface Release {
     assets: any[];
     assets_url: string;
     author: {
-        login: string;
-        id: number;
-        node_id: string;
         avatar_url: string;
-        gravatar_id: string;
-        url: string;
-        html_url: string;
+        events_url: string;
         followers_url: string;
         following_url: string;
         gists_url: string;
+        gravatar_id: string;
+        html_url: string;
+        id: number;
+        login: string;
+        node_id: string;
+        organizations_url: string;
+        received_events_url: string;
+        repos_url: string;
+        site_admin: boolean;
         starred_url: string;
         subscriptions_url: string;
-        organizations_url: string;
-        repos_url: string;
-        events_url: string;
-        received_events_url: string;
         type: string;
-        site_admin: boolean;
+        url: string;
     };
     body: string;
-    html_url: string;
-    name: string;
     created_at: string;
+    draft: boolean;
+    html_url: string;
     id: number;
     mentions_count: number;
-    draft: boolean;
-    prerelease: boolean;
+    name: string;
     node_id: string;
-    tag_name: string;
+    prerelease: boolean;
     published_at: string;
+    tag_name: string;
     tarball_url: string;
     target_commitish: string;
     upload_url: string;
     url: string;
     zipball_url: string;
 }
-
 export interface UseLatestReleaseResult
     extends UseQueryResult<unknown, unknown, Release> {}
 

--- a/src/utils/hooks/use-number-input.ts
+++ b/src/utils/hooks/use-number-input.ts
@@ -88,9 +88,9 @@ const useNumberInput = (
 
 const getValidationState = (
     value: number | undefined,
-    options: Pick<UseNumberInputOptions, "isRequired" | "min" | "max">
+    options: Pick<UseNumberInputOptions, "isRequired" | "max" | "min">
 ): ValidationState | undefined => {
-    const { isRequired, min, max } = options;
+    const { isRequired = false, min, max } = options;
     if (isRequired && value == null) {
         return ValueRequiredState;
     }

--- a/src/utils/hooks/use-query.ts
+++ b/src/utils/hooks/use-query.ts
@@ -20,7 +20,7 @@ interface UseQueryOptions<
             TResultObject,
             TQueryKey
         >,
-        "enabled" | "onSuccess" | "onError" | "onSettled" | "staleTime"
+        "enabled" | "onError" | "onSettled" | "onSuccess" | "staleTime"
     > {
     fn: QueryFunction<TResultObject, TQueryKey>;
     key?: TQueryKey | undefined;

--- a/src/utils/hooks/use-tone-audio.ts
+++ b/src/utils/hooks/use-tone-audio.ts
@@ -42,9 +42,9 @@ interface UseToneAudioOptions
     mimeType?: string;
     onRecordingComplete?: (recording: Blob) => void;
     startIndex?: number;
-    trackSectionSteps?: List<TrackSectionStepRecord>;
-    trackSections?: List<TrackSectionRecord>;
     tracks?: List<TrackRecord>;
+    trackSections?: List<TrackSectionRecord>;
+    trackSectionSteps?: List<TrackSectionStepRecord>;
 }
 
 interface UseToneAudioResult {
@@ -303,7 +303,7 @@ const cleanupTracks = (tracks: Map<string, ToneTrack>): void => {
 };
 
 const updateTracks = (
-    options: Pick<UseToneAudioOptions, "loop" | "isPlaying">,
+    options: Pick<UseToneAudioOptions, "isPlaying" | "loop">,
     tracks: Map<string, ToneTrack>
 ): void => {
     const { loop, isPlaying } = options;
@@ -312,7 +312,7 @@ const updateTracks = (
             toneTrack.sequence.loop = loop;
         }
 
-        if (isPlaying) {
+        if (isPlaying === true) {
             toneTrack.sequence.start(0);
             return;
         }

--- a/src/utils/hooks/use-tone-controls.ts
+++ b/src/utils/hooks/use-tone-controls.ts
@@ -38,13 +38,16 @@ const useToneControls = (): UseToneControlsResult => {
     const toggleIsPlaying = useCallback(
         () =>
             setState((prev) =>
-                mergeState(prev, { isPlaying: !prev.isPlaying })
+                mergeState(prev, { isPlaying: !(prev.isPlaying ?? false) })
             ),
         [setState]
     );
 
     const toggleMute = useCallback(
-        () => setState((prev) => mergeState(prev, { mute: !prev.mute })),
+        () =>
+            setState((prev) =>
+                mergeState(prev, { mute: !(prev.mute ?? false) })
+            ),
         [setState]
     );
 

--- a/src/utils/hooks/use-tone-playing-effect.ts
+++ b/src/utils/hooks/use-tone-playing-effect.ts
@@ -3,7 +3,7 @@ import * as Tone from "tone";
 
 const useTonePlayingEffect = (isPlaying?: boolean): void => {
     useEffect(() => {
-        if (isPlaying) {
+        if (isPlaying === true) {
             Tone.Transport.start();
             return;
         }

--- a/src/utils/keyboard-shortcut-utils.ts
+++ b/src/utils/keyboard-shortcut-utils.ts
@@ -60,7 +60,7 @@ const getDisplayLabel = (shortcut: string): string => {
     return isMacOs() ? displayLabel.replace("+", "") : displayLabel;
 };
 
-const hasKey = (shortcuts: string | string[], ...keys: string[]): boolean =>
+const hasKey = (shortcuts: string[] | string, ...keys: string[]): boolean =>
     hasValues(
         intersectionWith(castArray(shortcuts), keys, (shortcut, key) =>
             new RegExp(key, "i").test(shortcut)
@@ -71,7 +71,7 @@ const hasKey = (shortcuts: string | string[], ...keys: string[]): boolean =>
  * Backfills cross-platform keyboard shortcuts if not present
  * @example ["ctrl+a"] -> ["ctrl+a", "cmd+a"]
  */
-const remapShortcuts = (shortcut: string | string[]): string => {
+const remapShortcuts = (shortcut: string[] | string): string => {
     const shortcuts = sanitizeKeys(
         Array.isArray(shortcut) ? shortcut : shortcut.split(",")
     );

--- a/src/utils/midi-note-utils.ts
+++ b/src/utils/midi-note-utils.ts
@@ -3,7 +3,7 @@ import { MidiNote } from "types/midi-note";
 import { MidiNotes } from "constants/midi-notes";
 
 export const isMidiNote = (
-    maybeNote?: string | number
+    maybeNote?: number | string
 ): maybeNote is MidiNote => {
     if (isEmpty(maybeNote) || isNumber(maybeNote)) {
         return false;
@@ -11,5 +11,4 @@ export const isMidiNote = (
 
     return MidiNotes.some((midiNote) => midiNote === maybeNote);
 };
-
 export const isSharp = (note: MidiNote): boolean => note.includes("#");

--- a/src/utils/track-section-step-utils.ts
+++ b/src/utils/track-section-step-utils.ts
@@ -137,5 +137,4 @@ export {
     toInstrumentStepTypes,
     toSequencerStepTypes,
 };
-
 export type { ClampIndexToRangeOptions };

--- a/src/utils/use-query-utils.ts
+++ b/src/utils/use-query-utils.ts
@@ -6,7 +6,7 @@ const mergeUseQueryProperties = (
     ...others: UseQueryResult<unknown, Error>[]
 ): Pick<
     UseQueryResult<unknown, Error>,
-    "isError" | "isIdle" | "isLoading" | "isSuccess" | "error"
+    "error" | "isError" | "isIdle" | "isLoading" | "isSuccess"
 > => ({
     isError: first.isError || others.some((result) => result.isError),
     isIdle: first.isIdle || others.some((result) => result.isIdle),


### PR DESCRIPTION
- Swaps out `collation` with updated `eslint-plugin-collation`, adds additional `eslint-plugin-typescript-sort-keys` plugin to replace functionality
- Some rules that otherwise would be turned on are off for now until `create-react-app` can be upgraded (which in turn upgrades `eslint`/`@typescript-eslint`)