### PR TITLE
Bug: Sequencer samples can collide

### DIFF
--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -53,6 +53,10 @@ const isSnare = (file: AnyFile): boolean => {
     return pattern.test(getFileName(file));
 };
 
+/**
+ * Returns a map of public file url to a note for use with the PianoRoll component. For now,
+ * it only sets the root note at C4 and lets Tone pitch the sound up/down
+ */
 const toInstrumentMap = (file?: FileRecord): Record<MidiNote, string> => {
     if (file == null) {
         return {} as Record<MidiNote, string>;
@@ -79,6 +83,9 @@ const toSelectMenuItems = (
     );
 };
 
+/**
+ * Returns a mapping of public file urls to midi notes for use with the Sequencer component
+ */
 const toSequencerMap = (files?: List<FileRecord>): Record<MidiNote, string> => {
     if (isNilOrEmpty(files)) {
         return {} as Record<MidiNote, string>;

--- a/src/utils/hooks/use-tone-audio.ts
+++ b/src/utils/hooks/use-tone-audio.ts
@@ -132,8 +132,15 @@ const useToneAudio = (options: UseToneAudioOptions): UseToneAudioResult => {
                 );
             }
 
+            // Only map up samples that this specific Track uses to prevent collisions
+            const sequencerFiles = intersectionWith(
+                files,
+                trackSectionStepsForTrack,
+                (file, trackSectionStep) => file.id === trackSectionStep.file_id
+            );
+
             const sampleMap = track.isSequencer()
-                ? toSequencerMap(files)
+                ? toSequencerMap(sequencerFiles)
                 : toInstrumentMap(getFileById(instrument?.file_id, files));
 
             // If there's no samples to play yet, don't bother initializing a track etc.


### PR DESCRIPTION
Fixed a bug where Sequencer samples can collide due to mapping up _all_ files provided to the hook to _every_ track. Instead, we should only be mapping up the files that are being used for that particular Track. This was likely an oversight on my part, eagerly mapping up all of the files at once - there might be a slight delay after adding new samples to a Sequencer Track while it loads the new file, but this seems like a larger issue (i.e. unintentionally overwriting other samples while playing)