### PR TITLE
chore(conditional-tooltip.tsx): replaced shouldRender with standard i…

### DIFF
--- a/src/components/conditional-tooltip.tsx
+++ b/src/components/conditional-tooltip.tsx
@@ -1,20 +1,11 @@
-import type { TooltipProps as EvergreenTooltipProps } from "evergreen-ui";
+import type { TooltipProps } from "evergreen-ui";
 import { Tooltip as EvergreenTooltip } from "evergreen-ui";
 import type { PropsWithChildren } from "react";
-import { Fragment } from "react";
-
-interface TooltipProps extends EvergreenTooltipProps {
-    shouldRender?: boolean;
-}
 
 const ConditionalTooltip: React.FC<PropsWithChildren<TooltipProps>> = (
     props: PropsWithChildren<TooltipProps>
 ) => {
-    const { shouldRender = true, showDelay = 500, ...tooltipProps } = props;
-
-    if (!shouldRender) {
-        return <Fragment>{props.children}</Fragment>;
-    }
+    const { showDelay = 500, ...tooltipProps } = props;
 
     return (
         <EvergreenTooltip {...tooltipProps} showDelay={showDelay}>

--- a/src/components/conditional-tooltip.tsx
+++ b/src/components/conditional-tooltip.tsx
@@ -2,13 +2,20 @@ import type { TooltipProps } from "evergreen-ui";
 import { Tooltip as EvergreenTooltip } from "evergreen-ui";
 import type { PropsWithChildren } from "react";
 
-const ConditionalTooltip: React.FC<PropsWithChildren<TooltipProps>> = (
-    props: PropsWithChildren<TooltipProps>
-) => {
-    const { showDelay = 500, ...tooltipProps } = props;
+interface ConditionalTooltipProps extends Omit<TooltipProps, "isShown"> {
+    isShown: boolean;
+}
+
+const ConditionalTooltip: React.FC<
+    PropsWithChildren<ConditionalTooltipProps>
+> = (props: PropsWithChildren<ConditionalTooltipProps>) => {
+    const { showDelay = 500, isShown, ...tooltipProps } = props;
 
     return (
-        <EvergreenTooltip {...tooltipProps} showDelay={showDelay}>
+        <EvergreenTooltip
+            {...tooltipProps}
+            isShown={isShown ? undefined : false}
+            showDelay={showDelay}>
             {props.children}
         </EvergreenTooltip>
     );

--- a/src/components/sequencer/sequencer-step.tsx
+++ b/src/components/sequencer/sequencer-step.tsx
@@ -66,7 +66,7 @@ const SequencerStep: React.FC<SequencerStepProps> = (
     return (
         <ConditionalTooltip
             content="Select one or more samples to drop in"
-            isShown={isContentEmpty ? undefined : false}>
+            isShown={isContentEmpty}>
             <Card
                 border={true}
                 cursor={hasSamples ? "pointer" : "not-allowed"}

--- a/src/components/sequencer/sequencer-step.tsx
+++ b/src/components/sequencer/sequencer-step.tsx
@@ -61,10 +61,12 @@ const SequencerStep: React.FC<SequencerStepProps> = (
         [index, onChange, value]
     );
 
+    const isContentEmpty = !hasSamples && value.isEmpty();
+
     return (
         <ConditionalTooltip
             content="Select one or more samples to drop in"
-            shouldRender={!hasSamples && value.isEmpty()}>
+            isShown={isContentEmpty ? undefined : false}>
             <Card
                 border={true}
                 cursor={hasSamples ? "pointer" : "not-allowed"}


### PR DESCRIPTION
Updated the `ConditionalTooltip` component to use the `isShown` prop that ships with the Evergreen tooltip rather than a custom `shouldRender` prop since it duplicates existing functionality. 

fix #286