### PR TITLE
Add preview to file card

### DIFF
--- a/src/components/files/file-card.tsx
+++ b/src/components/files/file-card.tsx
@@ -13,12 +13,12 @@ import humanize from "humanize-plus";
 import { useDeleteFile } from "utils/hooks/domain/files/use-delete-file";
 import type { FileRecord } from "models/file-record";
 import type { StorageProviderFileRecord } from "models/storage-provider-file-record";
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
 import { useBoolean } from "utils/hooks/use-boolean";
 import { FileSettingsDialog } from "components/files/file-settings-dialog";
 import { Flex } from "components/flex";
 import { IconButton } from "components/icon-button";
-import { PlayButton } from "components/workstation/play-button";
+import { PlayPreviewButton } from "components/workstation/play-preview-button";
 
 interface FileCardProps
     extends Omit<EvergreenFileCardProps, "name" | "sizeInBytes" | "type"> {
@@ -28,26 +28,11 @@ interface FileCardProps
 
 const FileCard: React.FC<FileCardProps> = (props: FileCardProps) => {
     const { file, storageProviderFile } = props;
-    const audioRef = useRef<HTMLAudioElement>(null);
-
     const {
         value: isOpen,
         setTrue: handleOpenDialog,
         setFalse: handleCloseDialog,
     } = useBoolean(false);
-    const {
-        value: isPlaying,
-        toggle: toggleIsPlaying,
-        setFalse: setIsPlayingFalse,
-    } = useBoolean();
-    const handlePlayClick = useCallback((isPlaying: boolean) => {
-        if (isPlaying) {
-            audioRef.current?.pause();
-            return;
-        }
-
-        audioRef.current?.play();
-    }, []);
     const { mutate, isLoading } = useDeleteFile();
     const handleDelete = useCallback(() => mutate(file.id), [file.id, mutate]);
     const { colors } = useTheme();
@@ -100,22 +85,7 @@ const FileCard: React.FC<FileCardProps> = (props: FileCardProps) => {
                 </Flex.Column>
             </Flex.Row>
             <Flex.Row justifyContent="flex-end">
-                <PlayButton
-                    appearance="minimal"
-                    isPlaying={isPlaying}
-                    marginLeft={minorScale(1)}
-                    marginRight={majorScale(1)}
-                    marginY={minorScale(1)}
-                    onClick={handlePlayClick}
-                    size="small"
-                    toggleIsPlaying={toggleIsPlaying}
-                />
-                <audio
-                    onEnded={setIsPlayingFalse}
-                    preload="none"
-                    ref={audioRef}
-                    src={file.getPublicUrl()}
-                />
+                <PlayPreviewButton fileUrl={file.getPublicUrl()} />
                 <IconButton
                     appearance="minimal"
                     color={colors.gray600}

--- a/src/components/files/file-card.tsx
+++ b/src/components/files/file-card.tsx
@@ -13,11 +13,12 @@ import humanize from "humanize-plus";
 import { useDeleteFile } from "utils/hooks/domain/files/use-delete-file";
 import type { FileRecord } from "models/file-record";
 import type { StorageProviderFileRecord } from "models/storage-provider-file-record";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { useBoolean } from "utils/hooks/use-boolean";
 import { FileSettingsDialog } from "components/files/file-settings-dialog";
 import { Flex } from "components/flex";
 import { IconButton } from "components/icon-button";
+import { PlayButton } from "components/workstation/play-button";
 
 interface FileCardProps
     extends Omit<EvergreenFileCardProps, "name" | "sizeInBytes" | "type"> {
@@ -27,15 +28,31 @@ interface FileCardProps
 
 const FileCard: React.FC<FileCardProps> = (props: FileCardProps) => {
     const { file, storageProviderFile } = props;
+    const audioRef = useRef<HTMLAudioElement>(null);
+
     const {
         value: isOpen,
         setTrue: handleOpenDialog,
         setFalse: handleCloseDialog,
     } = useBoolean(false);
+    const {
+        value: isPlaying,
+        toggle: toggleIsPlaying,
+        setFalse: setIsPlayingFalse,
+    } = useBoolean();
+    const handlePlayClick = useCallback((isPlaying: boolean) => {
+        if (isPlaying) {
+            audioRef.current?.pause();
+            return;
+        }
+
+        audioRef.current?.play();
+    }, []);
     const { mutate, isLoading } = useDeleteFile();
     const handleDelete = useCallback(() => mutate(file.id), [file.id, mutate]);
     const { colors } = useTheme();
     const { name, size } = file;
+
     return (
         <Flex.Row
             alignItems="center"
@@ -83,6 +100,22 @@ const FileCard: React.FC<FileCardProps> = (props: FileCardProps) => {
                 </Flex.Column>
             </Flex.Row>
             <Flex.Row justifyContent="flex-end">
+                <PlayButton
+                    appearance="minimal"
+                    isPlaying={isPlaying}
+                    marginLeft={minorScale(1)}
+                    marginRight={majorScale(1)}
+                    marginY={minorScale(1)}
+                    onClick={handlePlayClick}
+                    size="small"
+                    toggleIsPlaying={toggleIsPlaying}
+                />
+                <audio
+                    onEnded={setIsPlayingFalse}
+                    preload="none"
+                    ref={audioRef}
+                    src={file.getPublicUrl()}
+                />
                 <IconButton
                     appearance="minimal"
                     color={colors.gray600}

--- a/src/components/files/file-select-menu-item.tsx
+++ b/src/components/files/file-select-menu-item.tsx
@@ -1,10 +1,9 @@
 import type { SelectMenuItemRendererProps } from "components/select-menu/select-menu";
 import type { FileRecord } from "models/file-record";
 import { majorScale, minorScale, Option } from "evergreen-ui";
-import { useBoolean } from "utils/hooks/use-boolean";
-import { PlayButton } from "components/workstation/play-button";
-import React, { useCallback, useRef } from "react";
+import React, { useCallback } from "react";
 import { isInstanceOf } from "utils/core-utils";
+import { PlayPreviewButton } from "components/workstation/play-preview-button";
 
 interface FileSelectMenuItemProps
     extends SelectMenuItemRendererProps<FileRecord> {}
@@ -17,20 +16,6 @@ const FileSelectMenuItem: React.FC<FileSelectMenuItemProps> = (
 ) => {
     const { item, isSelectable, isSelected, onSelect, onDeselect, ...rest } =
         props;
-    const {
-        value: isPlaying,
-        toggle: toggleIsPlaying,
-        setFalse: setIsPlayingFalse,
-    } = useBoolean();
-    const audioRef = useRef<HTMLAudioElement>(null);
-    const handlePlayClick = useCallback((isPlaying: boolean) => {
-        if (isPlaying) {
-            audioRef.current?.pause();
-            return;
-        }
-
-        audioRef.current?.play();
-    }, []);
 
     const handleClick = useCallback(
         (event: React.MouseEvent) => {
@@ -66,21 +51,12 @@ const FileSelectMenuItem: React.FC<FileSelectMenuItemProps> = (
             maxHeight={itemHeight}
             minHeight={itemHeight}
             onClick={handleClick}>
-            <PlayButton
-                appearance="minimal"
-                isPlaying={isPlaying}
+            <PlayPreviewButton
+                fileUrl={item.value.getPublicUrl()}
                 marginLeft={minorScale(1)}
                 marginRight={majorScale(1)}
                 marginY={minorScale(1)}
-                onClick={handlePlayClick}
                 size="small"
-                toggleIsPlaying={toggleIsPlaying}
-            />
-            <audio
-                onEnded={setIsPlayingFalse}
-                preload="none"
-                ref={audioRef}
-                src={item.value.getPublicUrl()}
             />
             {item.value.name}
         </Option>

--- a/src/components/workstation/play-button.tsx
+++ b/src/components/workstation/play-button.tsx
@@ -46,4 +46,4 @@ const PlayButton: React.FC<PlayButtonProps> = (props: PlayButtonProps) => {
     );
 };
 
-export { PlayButton };
+export { PlayButton, type PlayButtonProps };

--- a/src/components/workstation/play-preview-button.tsx
+++ b/src/components/workstation/play-preview-button.tsx
@@ -1,4 +1,3 @@
-import { majorScale, minorScale } from "evergreen-ui";
 import { useCallback, useRef } from "react";
 import { useBoolean } from "utils/hooks/use-boolean";
 import { PlayButton, type PlayButtonProps } from "./play-button";
@@ -11,7 +10,7 @@ interface PlayPreviewButtonProps
 const PlayPreviewButton: React.FC<PlayPreviewButtonProps> = (
     props: PlayPreviewButtonProps
 ) => {
-    const { disabled, fileUrl, isLoading, type, width, size } = props;
+    const { fileUrl, ...iconButtonProps } = props;
     const audioRef = useRef<HTMLAudioElement>(null);
     const {
         value: isPlaying,
@@ -30,15 +29,10 @@ const PlayPreviewButton: React.FC<PlayPreviewButtonProps> = (
         <>
             <PlayButton
                 appearance="minimal"
-                disabled={disabled}
-                isLoading={isLoading}
                 isPlaying={isPlaying}
                 onClick={handlePlayClick}
-                size={size}
                 toggleIsPlaying={toggleIsPlaying}
-                type={type}
-                width={width}
-                {...props}
+                {...iconButtonProps}
             />
             {fileUrl != null && (
                 <audio

--- a/src/components/workstation/play-preview-button.tsx
+++ b/src/components/workstation/play-preview-button.tsx
@@ -1,0 +1,55 @@
+import { majorScale, minorScale } from "evergreen-ui";
+import { useCallback, useRef } from "react";
+import { useBoolean } from "utils/hooks/use-boolean";
+import { PlayButton, type PlayButtonProps } from "./play-button";
+
+interface PlayPreviewButtonProps
+    extends Omit<PlayButtonProps, "isPlaying" | "toggleIsPlaying"> {
+    fileUrl?: string;
+}
+
+const PlayPreviewButton: React.FC<PlayPreviewButtonProps> = (
+    props: PlayPreviewButtonProps
+) => {
+    const { disabled, fileUrl, isLoading, type, width, size } = props;
+    const audioRef = useRef<HTMLAudioElement>(null);
+    const {
+        value: isPlaying,
+        toggle: toggleIsPlaying,
+        setFalse: setIsPlayingFalse,
+    } = useBoolean();
+    const handlePlayClick = useCallback((isPlaying: boolean) => {
+        if (isPlaying) {
+            audioRef.current?.pause();
+            return;
+        }
+
+        audioRef.current?.play();
+    }, []);
+    return (
+        <>
+            <PlayButton
+                appearance="minimal"
+                disabled={disabled}
+                isLoading={isLoading}
+                isPlaying={isPlaying}
+                onClick={handlePlayClick}
+                size={size}
+                toggleIsPlaying={toggleIsPlaying}
+                type={type}
+                width={width}
+                {...props}
+            />
+            {fileUrl != null && (
+                <audio
+                    onEnded={setIsPlayingFalse}
+                    preload="none"
+                    ref={audioRef}
+                    src={fileUrl}
+                />
+            )}
+        </>
+    );
+};
+
+export { PlayPreviewButton };


### PR DESCRIPTION
In addition to adding a preview button to the file card, I also abstracted play buttons that use an audioRef into a new component named `PlayPreviewButton`. Updated `file-select-menu-item.tsx` to use the new component.

Resolves #174 